### PR TITLE
main

### DIFF
--- a/examples/_build.vsh
+++ b/examples/_build.vsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env -S v
 
+chdir(dir(@FILE))!
+
 output_dir := 'bin'
 if exists(output_dir) {
 	bin_files := ls(output_dir) or { [] }

--- a/examples/_check.vsh
+++ b/examples/_check.vsh
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S v
 
+chdir(dir(@FILE))!
+unbuffer_stdout()
+
 dir_files := ls('.') or { [] }
 files := dir_files.filter(file_ext(it) == '.v').sorted()
 if files.len == 0 {
@@ -8,8 +11,7 @@ if files.len == 0 {
 }
 for i, file in files {
 	p := 'v -check ${file} '
-	print('(${i:02}) ${p:-30}')
-	flush()
+	print('(${i + 1:02}/${files.len:02}) ${p:-30}')
 	result := execute('v -check ${file}')
 	if result.exit_code == 0 {
 		println(' ✅')

--- a/examples/buttons.v
+++ b/examples/buttons.v
@@ -22,7 +22,7 @@ fn main() {
 	mut window := gui.window(
 		title:   'Buttons'
 		state:   &App{}
-		width:   350
+		width:   400
 		height:  375
 		on_init: fn (mut w gui.Window) {
 			w.update_view(main_view)

--- a/examples/image_demo.v
+++ b/examples/image_demo.v
@@ -1,6 +1,6 @@
+import os
 import gui
 
-@[heap]
 fn main() {
 	mut window := gui.window(
 		width:   600
@@ -15,6 +15,7 @@ fn main() {
 
 fn main_view(window &gui.Window) gui.View {
 	w, h := window.window_size()
+	sample_path := os.join_path(os.dir(@FILE), 'sample.jpeg')
 
 	return gui.column(
 		width:   w
@@ -23,7 +24,7 @@ fn main_view(window &gui.Window) gui.View {
 		h_align: .center
 		v_align: .middle
 		content: [
-			gui.image(file_name: 'sample.jpeg'),
+			gui.image(file_name: sample_path),
 			gui.text(text: 'Pinard Falls, Oregon', text_style: gui.theme().b2),
 		]
 	)

--- a/examples/tab-view.v
+++ b/examples/tab-view.v
@@ -15,7 +15,7 @@ pub mut:
 fn main() {
 	mut window := gui.window(
 		state:   &TabViewApp{}
-		width:   300
+		width:   400
 		height:  300
 		on_init: fn (mut w gui.Window) {
 			w.update_view(main_view)

--- a/window.v
+++ b/window.v
@@ -61,6 +61,7 @@ pub:
 		w.update_view(empty_view)
 	}
 	on_event fn (e &Event, mut w Window) = fn (_ &Event, mut _ Window) {}
+	samples  int                         = 2 // MSAA sample count; rounded courners of buttons with 0 and 1 look jagged on linux/windows
 }
 
 // window creates the application window. See [WindowCfg](#WindowCfg) on how to configure it
@@ -83,6 +84,7 @@ pub fn window(cfg &WindowCfg) &Window {
 			cfg.on_init(w)
 			w.update_window()
 		}
+		sample_count: cfg.samples
 	)
 	initialize_fonts()
 	return window


### PR DESCRIPTION
- **make _build.vsh independent from the current folder, so `v ~/.vmodules/gui/examples/_build.vsh` works**
- **show (07/25), enable `v ~/.vmodules/gui/examples/_check.vsh`**
- **enable `v ~/.vmodules/gui/examples/image_demo.v` (before the example used a relative path, so `sample.jpeg` could not be found, depending on the working folder)**
- **fix initial look of buttons.v on linux (the right side of the buttons was clipped); use gg's sample_count: 2 by default, to improve the rounded corners look**
- **prevent clipping by default on linux for examples/tab-view.v too**
