### PR TITLE
feat: expose WindowCfg.sample_count (MSAA) and forward to gg.new_context

### DIFF
--- a/window.v
+++ b/window.v
@@ -103,6 +103,7 @@ pub:
 	on_event            fn (e &Event, mut w Window) = fn (_ &Event, mut _ Window) {} // global event hook; fires for all events
 	log_level           log.Level                   = default_log_level()
 	debug_layout        bool // print layout timing stats to stdout each frame
+	sample_count        int = 1 // MSAA sample count (1 = off; 4 antialiases draw_canvas lines/polygons)
 }
 
 fn default_log_level() log.Level {
@@ -131,6 +132,7 @@ pub fn window(cfg &WindowCfg) &Window {
 		width:                        cfg.width
 		height:                       cfg.height
 		window_title:                 cfg.title
+		sample_count:                 cfg.sample_count
 		event_fn:                     event_fn
 		enable_dragndrop:             cfg.dragndrop
 		max_dropped_files:            int(cfg.dragndrop_files_max)


### PR DESCRIPTION
`gg` already supports MSAA through `Config.sample_count`, and `gg.new_context()` forwards it to sokol — but `gui` hard-codes the default (`1` = off) and gives apps no way to turn it on.

This adds a `sample_count` field to `WindowCfg` (default `1`, so it's a no-op for every existing app) and forwards it to `gg.new_context()`:

```v
pub struct WindowCfg {
pub:
	...
	sample_count int = 1 // MSAA sample count (1 = off; 4 antialiases draw_canvas lines/polygons)
}
```

With `sample_count: 4`, `draw_canvas` lines/polygons (e.g. real-time signal plots) render antialiased instead of jagged. No behaviour change unless an app opts in.

`v fmt`-clean; two added lines (the field + the pass-through).
