### PR TITLE
fix(dock): tabbed panel groups render a blank gap above their content

### DIFF
--- a/view_dock_layout.v
+++ b/view_dock_layout.v
@@ -203,7 +203,10 @@ fn dock_group_view(core &DockLayoutCore, group &DockNode, cfg DockLayoutCfg, dra
 		}
 
 		if tab_buttons.len > 0 {
-			tab_buttons << column(width: 1, sizing: fixed_fill, color: color_sep)
+			// Use a definite height, not fixed_fill: a height-fill child inside the
+			// fit-height tab-bar row makes the row expand to fill the group, leaving a
+			// large blank gap above the panel content whenever a group has 2+ tabs.
+			tab_buttons << column(width: 1, height: 20, sizing: fixed_fixed, color: color_sep)
 		}
 		tab_buttons << dock_tab_button(core, group, panel_def, is_selected, cfg)
 	}


### PR DESCRIPTION
## Problem

A dock panel group with **2+ tabs** (e.g. created by dragging one panel onto another via the center/tabify drop zone) renders a large empty band **between the tab bar and the panel content**. Single-tab groups are fine, so it only appears once a group has more than one tab.

## Cause

In `view_dock_layout.v`, the per-tab separator is built as:

```v
tab_buttons << column(width: 1, sizing: fixed_fill, color: color_sep)
```

That's a height-**fill** child placed inside the **fit-height** `dock_tab_bar` row (`sizing: fill_fit`). A fill child in a fit container makes the row expand to fill the available group height instead of fitting the tabs, so the tab bar balloons and pushes the content down. The separator is only added *between* tabs, which is why the gap appears only with 2+ tabs.

## Fix

Give the separator a definite height (`fixed_fixed`) instead of `fixed_fill`, so the tab bar fits its tabs again. The divider is still drawn.

```v
tab_buttons << column(width: 1, height: 20, sizing: fixed_fixed, color: color_sep)
```

## Repro

Put two panels in one group:

```v
dock_panel_group('g', ['a', 'b'], 'a')
```

Before: a blank band sits above the content. After: content sits directly under the tab bar.

Verified in a real ~25-panel dockable app: tabbing any two panels together now renders cleanly.