### PR TITLE
clean: v-gui notices and test CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,17 @@ jobs:
       - name: Run tests
         env:
           VFLAGS: -no-parallel -cc clang
-        run: v test gui/
+        run: |
+          test_manifest="${RUNNER_TEMP}/gui-test-files"
+          git -C gui ls-files '*_test.v' | LC_ALL=C sort > "$test_manifest"
+          test_count="$(wc -l < "$test_manifest" | tr -d ' ')"
+          echo "Test files: $test_count"
+          i=0
+          while IFS= read -r file; do
+            i=$((i + 1))
+            echo "[$i/$test_count] gui/$file"
+          done < "$test_manifest"
+          v test gui/
       - name: Check compilation of examples
         if: github.event_name == 'pull_request'
         env:
@@ -387,7 +397,13 @@ jobs:
           VFLAGS: -no-parallel -cc msvc
           VJOBS: 1
           VTEST_ONLY_FN: test_*
-        run: v test gui/
+        run: |
+          $testFiles = @(git -C gui ls-files '*_test.v' | Sort-Object)
+          Write-Host "Test files: $($testFiles.Count)"
+          for ($i = 0; $i -lt $testFiles.Count; $i++) {
+            Write-Host ("[{0}/{1}] gui/{2}" -f ($i + 1), $testFiles.Count, $testFiles[$i])
+          }
+          v test gui/
       - name: Check compilation of examples
         if: github.event_name == 'pull_request'
         env:

--- a/_data_source_orm_test.v
+++ b/_data_source_orm_test.v
@@ -257,7 +257,7 @@ fn test_grid_orm_data_source_mutate_create_update_delete() {
 	mut source := GridOrmDataSource{
 		columns:        orm_test_columns()
 		fetch_fn:       orm_test_fetch_ok
-		create_fn:      fn (rows []gui.GridRow, _ &GridAbortSignal) ![]gui.GridRow {
+		create_fn:      fn (rows []GridRow, _ &GridAbortSignal) ![]GridRow {
 			assert rows.len == 1
 			return [
 				GridRow{
@@ -266,7 +266,7 @@ fn test_grid_orm_data_source_mutate_create_update_delete() {
 				},
 			]
 		}
-		update_fn:      fn (_ []gui.GridRow, edits []gui.GridCellEdit, _ &GridAbortSignal) ![]gui.GridRow {
+		update_fn:      fn (_ []GridRow, edits []GridCellEdit, _ &GridAbortSignal) ![]GridRow {
 			assert edits.len == 1
 			return [
 				GridRow{
@@ -414,10 +414,10 @@ fn test_grid_orm_capabilities_with_mutation_fns() {
 	mut source := GridOrmDataSource{
 		columns:        orm_test_columns()
 		fetch_fn:       orm_test_fetch_ok
-		create_fn:      fn (_ []gui.GridRow, _ &GridAbortSignal) ![]gui.GridRow {
+		create_fn:      fn (_ []GridRow, _ &GridAbortSignal) ![]GridRow {
 			return []GridRow{}
 		}
-		update_fn:      fn (_ []gui.GridRow, _ []gui.GridCellEdit, _ &GridAbortSignal) ![]gui.GridRow {
+		update_fn:      fn (_ []GridRow, _ []GridCellEdit, _ &GridAbortSignal) ![]GridRow {
 			return []GridRow{}
 		}
 		delete_many_fn: fn (_ []string, _ &GridAbortSignal) ![]string {
@@ -474,7 +474,7 @@ fn test_grid_orm_data_source_mutate_honors_abort() {
 	mut source := GridOrmDataSource{
 		columns:   orm_test_columns()
 		fetch_fn:  orm_test_fetch_ok
-		create_fn: fn (_ []gui.GridRow, _ &GridAbortSignal) ![]gui.GridRow {
+		create_fn: fn (_ []GridRow, _ &GridAbortSignal) ![]GridRow {
 			return []GridRow{}
 		}
 	}
@@ -1018,7 +1018,7 @@ fn orm_test_columns() []GridOrmColumnSpec {
 	]
 }
 
-fn orm_test_rows(ids []string) []gui.GridRow {
+fn orm_test_rows(ids []string) []GridRow {
 	mut rows := []GridRow{cap: ids.len}
 	for id in ids {
 		rows << GridRow{

--- a/_dock_layout_tree_test.v
+++ b/_dock_layout_tree_test.v
@@ -1,0 +1,126 @@
+module gui
+
+fn dock_test_group(id string, panel_ids []string, selected_id string) &DockNode {
+	return dock_panel_group(id, panel_ids, selected_id)
+}
+
+fn dock_test_root() &DockNode {
+	left := dock_test_group('left', ['left_a', 'left_b'], 'left_b')
+	right := dock_test_group('right', ['right_a'], 'right_a')
+	return dock_split('root', .horizontal, 0.35, left, right)
+}
+
+fn dock_same_node(a &DockNode, b &DockNode) bool {
+	return unsafe { a == b }
+}
+
+fn test_dock_tree_remove_absent_panel_returns_same_root() {
+	root := dock_test_root()
+	same_root := dock_tree_remove_panel(root, 'missing')
+
+	assert dock_same_node(same_root, root)
+	assert root.kind == .split
+	assert root.first.panel_ids == ['left_a', 'left_b']
+	assert root.first.selected_id == 'left_b'
+	assert root.second.panel_ids == ['right_a']
+}
+
+fn test_dock_tree_remove_selected_tab_selects_first_remaining_tab() {
+	root := dock_test_root()
+	new_root := dock_tree_remove_panel(root, 'left_b')
+
+	assert !dock_same_node(new_root, root)
+	assert !dock_same_node(new_root.first, root.first)
+	assert dock_same_node(new_root.second, root.second)
+	assert new_root.first.panel_ids == ['left_a']
+	assert new_root.first.selected_id == 'left_a'
+	assert root.first.panel_ids == ['left_a', 'left_b']
+	assert root.first.selected_id == 'left_b'
+}
+
+fn test_dock_tree_remove_last_panel_collapses_split_to_sibling() {
+	root := dock_test_root()
+	new_root := dock_tree_remove_panel(root, 'right_a')
+
+	assert dock_same_node(new_root, root.first)
+	assert new_root.id == 'left'
+	assert new_root.panel_ids == ['left_a', 'left_b']
+}
+
+fn test_dock_tree_add_tab_appends_and_selects_added_panel() {
+	root := dock_test_root()
+	new_root := dock_tree_add_tab(root, 'right', 'right_b')
+
+	assert !dock_same_node(new_root, root)
+	assert dock_same_node(new_root.first, root.first)
+	assert !dock_same_node(new_root.second, root.second)
+	assert new_root.second.panel_ids == ['right_a', 'right_b']
+	assert new_root.second.selected_id == 'right_b'
+	assert root.second.panel_ids == ['right_a']
+	assert root.second.selected_id == 'right_a'
+}
+
+fn test_dock_tree_split_at_preserves_direction_and_child_ordering() {
+	base := dock_test_group('target', ['existing'], 'existing')
+
+	left := dock_tree_split_at(base, 'target', 'new_left', .left)
+	assert left.dir == .horizontal
+	assert left.first.panel_ids == ['new_left']
+	assert left.second.panel_ids == ['existing']
+
+	right := dock_tree_split_at(base, 'target', 'new_right', .right)
+	assert right.dir == .horizontal
+	assert right.first.panel_ids == ['existing']
+	assert right.second.panel_ids == ['new_right']
+
+	top := dock_tree_split_at(base, 'target', 'new_top', .top)
+	assert top.dir == .vertical
+	assert top.first.panel_ids == ['new_top']
+	assert top.second.panel_ids == ['existing']
+
+	bottom := dock_tree_split_at(base, 'target', 'new_bottom', .bottom)
+	assert bottom.dir == .vertical
+	assert bottom.first.panel_ids == ['existing']
+	assert bottom.second.panel_ids == ['new_bottom']
+}
+
+fn test_dock_tree_move_center_removes_then_adds_tab() {
+	root := dock_test_root()
+	new_root := dock_tree_move_panel(root, 'left_b', 'right', .center)
+
+	assert new_root.kind == .split
+	assert new_root.first.panel_ids == ['left_a']
+	assert new_root.first.selected_id == 'left_a'
+	assert new_root.second.panel_ids == ['right_a', 'left_b']
+	assert new_root.second.selected_id == 'left_b'
+	assert root.first.panel_ids == ['left_a', 'left_b']
+	assert root.second.panel_ids == ['right_a']
+}
+
+fn test_dock_tree_move_window_edge_wraps_after_remove() {
+	root := dock_test_root()
+	new_root := dock_tree_move_panel(root, 'left_b', '', .window_right)
+
+	assert new_root.kind == .split
+	assert new_root.dir == .horizontal
+	assert new_root.ratio == f32(0.8)
+	assert new_root.first.kind == .split
+	assert new_root.first.first.panel_ids == ['left_a']
+	assert new_root.first.second.panel_ids == ['right_a']
+	assert new_root.second.panel_ids == ['left_b']
+	assert new_root.second.selected_id == 'left_b'
+}
+
+fn test_dock_tree_select_panel_noop_and_change_behavior() {
+	root := dock_test_root()
+	same_root := dock_tree_select_panel(root, 'left', 'left_b')
+	new_root := dock_tree_select_panel(root, 'left', 'left_a')
+
+	assert dock_same_node(same_root, root)
+	assert !dock_same_node(new_root, root)
+	assert !dock_same_node(new_root.first, root.first)
+	assert dock_same_node(new_root.second, root.second)
+	assert new_root.first.panel_ids == ['left_a', 'left_b']
+	assert new_root.first.selected_id == 'left_a'
+	assert root.first.selected_id == 'left_b'
+}

--- a/_window_lifetime_test.v
+++ b/_window_lifetime_test.v
@@ -274,7 +274,7 @@ fn lifetime_grid_columns() []GridColumnCfg {
 	]
 }
 
-fn lifetime_grid_rows() []gui.GridRow {
+fn lifetime_grid_rows() []GridRow {
 	return [
 		GridRow{
 			id:    'row-1'
@@ -827,7 +827,7 @@ fn start_lifetime_capturing_crud_save(mut w Window, mut harness &LifetimeCrudSav
 			on_crud_error:       fn [payload, mut harness] (_ string, mut _ Event, mut _ Window) {
 				harness.error_sum = payload[0] + payload[payload.len - 1]
 			}
-			on_rows_change:      fn [payload, mut harness] (_ []gui.GridRow, mut _ Event, mut _ Window) {
+			on_rows_change:      fn [payload, mut harness] (_ []GridRow, mut _ Event, mut _ Window) {
 				harness.rows_change_sum = payload[0] + payload[payload.len - 1]
 			}
 			selection:           GridSelection{

--- a/animation.v
+++ b/animation.v
@@ -186,7 +186,7 @@ fn max_animation_refresh_kind(current AnimationRefreshKind, incoming AnimationRe
 	return .none
 }
 
-fn update_animate(mut an Animate, mut w Window, mut deferred []AnimationCallback) bool {
+fn update_animate(mut an Animate, mut _ Window, mut deferred []AnimationCallback) bool {
 	if !an.stopped {
 		if time.since(an.start) > an.delay {
 			// Capture callback to call after lock release

--- a/animation_hero.v
+++ b/animation_hero.v
@@ -158,7 +158,7 @@ fn capture_heroes_recursive(layout Layout, mut snapshots map[string]HeroSnapshot
 	}
 }
 
-fn update_hero_transition(mut ht HeroTransition, mut w Window, mut deferred []AnimationCallback) bool {
+fn update_hero_transition(mut ht HeroTransition, mut _ Window, mut deferred []AnimationCallback) bool {
 	if ht.stopped {
 		return false
 	}

--- a/animation_keyframe.v
+++ b/animation_keyframe.v
@@ -107,7 +107,7 @@ fn (_ KeyframeAnimation) refresh_kind() AnimationRefreshKind {
 	return .layout
 }
 
-fn update_keyframe(mut kf KeyframeAnimation, mut w Window, mut deferred []AnimationCallback) bool {
+fn update_keyframe(mut kf KeyframeAnimation, mut _ Window, mut deferred []AnimationCallback) bool {
 	if kf.stopped {
 		return false
 	}

--- a/animation_layout.v
+++ b/animation_layout.v
@@ -162,7 +162,7 @@ fn capture_recursive(layout Layout, mut snapshots map[string]LayoutSnapshot) {
 	}
 }
 
-fn update_layout_transition(mut lt LayoutTransition, mut w Window, mut deferred []AnimationCallback) bool {
+fn update_layout_transition(mut lt LayoutTransition, mut _ Window, mut deferred []AnimationCallback) bool {
 	if lt.stopped {
 		return false
 	}

--- a/animation_spring.v
+++ b/animation_spring.v
@@ -206,7 +206,7 @@ pub fn (mut s SpringAnimation) retarget(to f32) {
 	s.stopped = false
 }
 
-fn update_spring(mut sp SpringAnimation, mut w Window, dt f32, mut deferred []AnimationCallback) bool {
+fn update_spring(mut sp SpringAnimation, mut _ Window, dt f32, mut deferred []AnimationCallback) bool {
 	if sp.stopped || sp.state.at_rest {
 		return false
 	}

--- a/animation_tween.v
+++ b/animation_tween.v
@@ -164,7 +164,7 @@ fn (_ TweenAnimation) refresh_kind() AnimationRefreshKind {
 	return .layout
 }
 
-fn update_tween(mut tw TweenAnimation, mut w Window, mut deferred []AnimationCallback) bool {
+fn update_tween(mut tw TweenAnimation, mut _ Window, mut deferred []AnimationCallback) bool {
 	if tw.stopped {
 		return false
 	}

--- a/color_hsv.v
+++ b/color_hsv.v
@@ -94,9 +94,9 @@ pub fn (c Color) to_hex_string() string {
 
 // hex_byte formats a u8 as a two-character uppercase hex string.
 fn hex_byte(b u8) string {
-	hex := '0123456789ABCDEF'
-	hi := hex[b >> 4]
-	lo := hex[b & 0x0F]
+	hex_digits := '0123456789ABCDEF'
+	hi := hex_digits[b >> 4]
+	lo := hex_digits[b & 0x0F]
 	mut res := []u8{len: 2}
 	res[0] = hi
 	res[1] = lo

--- a/dock_layout_drag.v
+++ b/dock_layout_drag.v
@@ -145,11 +145,11 @@ fn dock_drag_cancel(dock_id string, mut w Window) {
 // panel_nodes is pre-collected at drag activation to avoid per-move
 // allocations.
 fn dock_drag_detect_zone(dock_id string, panel_nodes []&DockNode,
-	mouse_x f32, mouse_y f32, source_group string, panel_id string,
+	mouse_x f32, mouse_y f32, source_group string, _ string,
 	w &Window) (DockDropZone, string) {
 	// 1. Check window-edge zones first.
-	dock_layout := w.find_layout_by_id(dock_id) or { return DockDropZone.none, '' }
-	clip := dock_layout.shape.shape_clip
+	dock_layout_node := w.find_layout_by_id(dock_id) or { return DockDropZone.none, '' }
+	clip := dock_layout_node.shape.shape_clip
 	if clip.width <= 0 || clip.height <= 0 {
 		return DockDropZone.none, ''
 	}
@@ -281,20 +281,20 @@ fn dock_drag_amend_overlay(dock_id string, color_zone Color, mut layout Layout, 
 	}
 
 	// Determine target rect.
-	mut tx, mut ty, mut tw, mut th := f32(0), f32(0), f32(0), f32(0)
+	mut tx, mut ty, mut tw, mut target_h := f32(0), f32(0), f32(0), f32(0)
 
 	if state.hover_zone == .window_top || state.hover_zone == .window_bottom
 		|| state.hover_zone == .window_left || state.hover_zone == .window_right {
 		tx = layout.shape.x
 		ty = layout.shape.y
 		tw = layout.shape.width
-		th = layout.shape.height
+		target_h = layout.shape.height
 	} else if state.hover_group_id.len > 0 {
 		group_layout := layout.find_by_id(state.hover_group_id) or { return }
 		tx = group_layout.shape.x
 		ty = group_layout.shape.y
 		tw = group_layout.shape.width
-		th = group_layout.shape.height
+		target_h = group_layout.shape.height
 	} else {
 		return
 	}
@@ -302,11 +302,11 @@ fn dock_drag_amend_overlay(dock_id string, color_zone Color, mut layout Layout, 
 	// Subdivide based on zone.
 	match state.hover_zone {
 		.top, .window_top {
-			th = th * 0.5
+			target_h = target_h * 0.5
 		}
 		.bottom, .window_bottom {
-			ty = ty + th * 0.5
-			th = th * 0.5
+			ty = ty + target_h * 0.5
+			target_h = target_h * 0.5
 		}
 		.left, .window_left {
 			tw = tw * 0.5
@@ -322,6 +322,6 @@ fn dock_drag_amend_overlay(dock_id string, color_zone Color, mut layout Layout, 
 	layout.children[overlay_idx].shape.x = tx
 	layout.children[overlay_idx].shape.y = ty
 	layout.children[overlay_idx].shape.width = tw
-	layout.children[overlay_idx].shape.height = th
+	layout.children[overlay_idx].shape.height = target_h
 	layout.children[overlay_idx].shape.color = color_zone
 }

--- a/dock_layout_tree.v
+++ b/dock_layout_tree.v
@@ -129,30 +129,26 @@ pub fn dock_tree_find_group_by_id(node &DockNode, group_id string) ?&DockNode {
 // group becomes empty, collapses the parent split (replaces it
 // with the remaining sibling). Returns the new root.
 pub fn dock_tree_remove_panel(root &DockNode, panel_id string) &DockNode {
-	return dock_tree_remove_panel_rec(root, panel_id)
-}
-
-fn dock_tree_remove_panel_rec(nd &DockNode, panel_id string) &DockNode {
-	orig := unsafe { nd }
-	if nd.kind == .split {
-		if nd.first == unsafe { nil } || nd.second == unsafe { nil } {
+	orig := unsafe { root }
+	if root.kind == .split {
+		if root.first == unsafe { nil } || root.second == unsafe { nil } {
 			return orig
 		}
-		new_first := dock_tree_remove_panel_rec(nd.first, panel_id)
-		new_second := dock_tree_remove_panel_rec(nd.second, panel_id)
+		new_first := dock_tree_remove_panel(root.first, panel_id)
+		new_second := dock_tree_remove_panel(root.second, panel_id)
 		if dock_tree_is_empty(new_first) {
 			return new_second
 		}
 		if dock_tree_is_empty(new_second) {
 			return new_first
 		}
-		if new_first != nd.first || new_second != nd.second {
-			return dock_split(nd.id, nd.dir, nd.ratio, new_first, new_second)
+		if new_first != root.first || new_second != root.second {
+			return dock_split(root.id, root.dir, root.ratio, new_first, new_second)
 		}
 		return orig
 	} else {
 		mut found := false
-		for id in nd.panel_ids {
+		for id in root.panel_ids {
 			if id == panel_id {
 				found = true
 				break
@@ -161,8 +157,8 @@ fn dock_tree_remove_panel_rec(nd &DockNode, panel_id string) &DockNode {
 		if !found {
 			return orig
 		}
-		mut new_ids := []string{cap: if nd.panel_ids.len > 0 { nd.panel_ids.len - 1 } else { 0 }}
-		for id in nd.panel_ids {
+		mut new_ids := []string{cap: if root.panel_ids.len > 0 { root.panel_ids.len - 1 } else { 0 }}
+		for id in root.panel_ids {
 			if id != panel_id {
 				new_ids << id
 			}
@@ -170,11 +166,11 @@ fn dock_tree_remove_panel_rec(nd &DockNode, panel_id string) &DockNode {
 		if new_ids.len == 0 {
 			return dock_panel_group('__dock_empty__', []string{}, '')
 		}
-		mut new_selected := nd.selected_id
+		mut new_selected := root.selected_id
 		if new_selected == panel_id {
 			new_selected = new_ids[0]
 		}
-		return dock_panel_group(nd.id, new_ids, new_selected)
+		return dock_panel_group(root.id, new_ids, new_selected)
 	}
 }
 
@@ -185,28 +181,24 @@ fn dock_tree_is_empty(node &DockNode) bool {
 // dock_tree_add_tab adds a panel to an existing group (by group_id).
 // Returns the new root.
 pub fn dock_tree_add_tab(root &DockNode, group_id string, panel_id string) &DockNode {
-	return dock_tree_add_tab_rec(root, group_id, panel_id)
-}
-
-fn dock_tree_add_tab_rec(nd &DockNode, group_id string, panel_id string) &DockNode {
-	orig := unsafe { nd }
-	if nd.kind == .split {
-		if nd.first == unsafe { nil } || nd.second == unsafe { nil } {
+	orig := unsafe { root }
+	if root.kind == .split {
+		if root.first == unsafe { nil } || root.second == unsafe { nil } {
 			return orig
 		}
-		new_first := dock_tree_add_tab_rec(nd.first, group_id, panel_id)
-		new_second := dock_tree_add_tab_rec(nd.second, group_id, panel_id)
-		if new_first != nd.first || new_second != nd.second {
-			return dock_split(nd.id, nd.dir, nd.ratio, new_first, new_second)
+		new_first := dock_tree_add_tab(root.first, group_id, panel_id)
+		new_second := dock_tree_add_tab(root.second, group_id, panel_id)
+		if new_first != root.first || new_second != root.second {
+			return dock_split(root.id, root.dir, root.ratio, new_first, new_second)
 		}
 		return orig
 	} else {
-		if nd.id != group_id {
+		if root.id != group_id {
 			return orig
 		}
-		mut new_ids := nd.panel_ids.clone()
+		mut new_ids := root.panel_ids.clone()
 		new_ids << panel_id
-		return dock_panel_group(nd.id, new_ids, panel_id)
+		return dock_panel_group(root.id, new_ids, panel_id)
 	}
 }
 
@@ -214,27 +206,23 @@ fn dock_tree_add_tab_rec(nd &DockNode, group_id string, panel_id string) &DockNo
 // split containing the original group and a new single-panel group.
 // The new panel goes into the position indicated by zone.
 pub fn dock_tree_split_at(root &DockNode, group_id string, panel_id string, zone DockDropZone) &DockNode {
-	return dock_tree_split_at_rec(root, group_id, panel_id, zone)
-}
-
-fn dock_tree_split_at_rec(nd &DockNode, group_id string, panel_id string, zone DockDropZone) &DockNode {
-	orig := unsafe { nd }
-	if nd.kind == .split {
-		if nd.first == unsafe { nil } || nd.second == unsafe { nil } {
+	orig := unsafe { root }
+	if root.kind == .split {
+		if root.first == unsafe { nil } || root.second == unsafe { nil } {
 			return orig
 		}
-		new_first := dock_tree_split_at_rec(nd.first, group_id, panel_id, zone)
-		new_second := dock_tree_split_at_rec(nd.second, group_id, panel_id, zone)
-		if new_first != nd.first || new_second != nd.second {
-			return dock_split(nd.id, nd.dir, nd.ratio, new_first, new_second)
+		new_first := dock_tree_split_at(root.first, group_id, panel_id, zone)
+		new_second := dock_tree_split_at(root.second, group_id, panel_id, zone)
+		if new_first != root.first || new_second != root.second {
+			return dock_split(root.id, root.dir, root.ratio, new_first, new_second)
 		}
 		return orig
 	} else {
-		if nd.id != group_id {
+		if root.id != group_id {
 			return orig
 		}
 		new_group := dock_panel_group('${group_id}_new_${panel_id}', [panel_id], panel_id)
-		existing := dock_panel_group(nd.id, nd.panel_ids, nd.selected_id)
+		existing := dock_panel_group(root.id, root.panel_ids, root.selected_id)
 		dir := dock_zone_to_split_dir(zone)
 		first_is_new := zone == .left || zone == .top
 		return dock_split('${group_id}_split', dir, 0.5, if first_is_new {
@@ -263,16 +251,14 @@ pub fn dock_tree_wrap_root(root &DockNode, panel_id string, zone DockDropZone) &
 // inserts it at the target: either as a tab (center zone) or as a
 // new split (edge zones). Returns the new root.
 pub fn dock_tree_move_panel(root &DockNode, panel_id string, target_group_id string, zone DockDropZone) &DockNode {
-	mut new_root := dock_tree_remove_panel(root, panel_id)
+	removed_root := dock_tree_remove_panel(root, panel_id)
 	if zone == .center {
-		new_root = dock_tree_add_tab(new_root, target_group_id, panel_id)
+		return dock_tree_add_tab(removed_root, target_group_id, panel_id)
 	} else if zone == .window_top || zone == .window_bottom || zone == .window_left
 		|| zone == .window_right {
-		new_root = dock_tree_wrap_root(new_root, panel_id, zone)
-	} else {
-		new_root = dock_tree_split_at(new_root, target_group_id, panel_id, zone)
+		return dock_tree_wrap_root(removed_root, panel_id, zone)
 	}
-	return new_root
+	return dock_tree_split_at(removed_root, target_group_id, panel_id, zone)
 }
 
 // dock_tree_select_panel sets the selected panel in the group with

--- a/examples/blur_demo.v
+++ b/examples/blur_demo.v
@@ -13,7 +13,7 @@ fn main() {
 	window.run()
 }
 
-fn main_view(mut w gui.Window) gui.View {
+fn main_view(mut _w gui.Window) gui.View {
 	return gui.column(
 		sizing:  gui.fit_fit
 		spacing: 60

--- a/examples/border_demo.v
+++ b/examples/border_demo.v
@@ -18,7 +18,7 @@ fn main() {
 	window.run()
 }
 
-fn main_view(window &gui.Window) gui.View {
+fn main_view(_window &gui.Window) gui.View {
 	return gui.column(gui.ContainerCfg{
 		width:   win_width
 		height:  win_height

--- a/examples/floating_layout.v
+++ b/examples/floating_layout.v
@@ -97,7 +97,7 @@ fn main_view(window &gui.Window) gui.View {
 	)
 }
 
-fn faux_edit_menu(app &FloatingLayoutApp) gui.View {
+fn faux_edit_menu(_app &FloatingLayoutApp) gui.View {
 	return gui.column(
 		spacing: 0
 		padding: gui.padding_none

--- a/examples/fractional_size_demo.v
+++ b/examples/fractional_size_demo.v
@@ -12,7 +12,7 @@ fn main() {
 	window.run()
 }
 
-fn main_view(window &gui.Window) gui.View {
+fn main_view(_window &gui.Window) gui.View {
 	sizes := [f32(10.0), 10.5, 11.0, 11.2, 11.5, 11.8, 12.0, 12.25, 12.5, 12.75, 13.0, 14.0]
 	mut texts := []gui.View{}
 

--- a/examples/gradient_border_demo.v
+++ b/examples/gradient_border_demo.v
@@ -13,7 +13,7 @@ fn main() {
 	window.run()
 }
 
-fn main_view(mut w gui.Window) gui.View {
+fn main_view(mut _w gui.Window) gui.View {
 	return gui.column(
 		sizing:  gui.fit_fit
 		spacing: 60

--- a/examples/menu_demo.v
+++ b/examples/menu_demo.v
@@ -202,7 +202,7 @@ fn menu(mut window gui.Window) gui.View {
 	)
 }
 
-fn body(mut app MenuApp, window &gui.Window) gui.View {
+fn body(mut app MenuApp, _window &gui.Window) gui.View {
 	return gui.column(
 		h_align: .center
 		padding: gui.padding_none

--- a/examples/showcase.v
+++ b/examples/showcase.v
@@ -832,7 +832,7 @@ fn selected_entry(entries []DemoEntry, selected string) DemoEntry {
 	return entries[0]
 }
 
-fn preferred_component_for_group(group string, entries []DemoEntry) string {
+fn preferred_component_for_group(_group string, entries []DemoEntry) string {
 	if entries.len == 0 {
 		return ''
 	}
@@ -1830,9 +1830,7 @@ fn menu(mut window gui.Window) gui.View {
 
 const svg_home = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>'
 const svg_settings = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>'
-const svg_star = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>'
 const svg_heart = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>'
-const svg_check = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>'
 const svg_clip_demo = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80"><defs><clipPath id="c"><circle cx="40" cy="40" r="28"/></clipPath></defs><rect x="4" y="4" width="112" height="72" fill="#3f80ff" clip-path="url(#c)"/><circle cx="80" cy="40" r="28" fill="#ff8c00"/></svg>'
 const svg_stroke_demo = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 80"><line x1="12" y1="16" x2="118" y2="16" stroke="#56b6ff" stroke-width="10" stroke-linecap="butt"/><line x1="12" y1="40" x2="118" y2="40" stroke="#9be564" stroke-width="10" stroke-linecap="round"/><polyline points="12,68 45,52 78,68 111,52" fill="none" stroke="#ff8c66" stroke-width="8" stroke-linejoin="round"/></svg>'
 const svg_transform_demo = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 90"><rect x="8" y="10" width="24" height="24" fill="#7aa2ff"/><g transform="translate(48,22) rotate(20)"><rect x="-12" y="-12" width="24" height="24" fill="#57d39b"/></g><g transform="translate(94,26) rotate(-30) scale(1.3,0.8)"><rect x="-12" y="-12" width="24" height="24" fill="#ffb04d"/></g><g transform="translate(120,62) skewX(25)"><rect x="-12" y="-10" width="24" height="20" fill="#ff7d9c"/></g></svg>'
@@ -1866,8 +1864,8 @@ fn on_select(id string, mut w gui.Window) {
 	app.tree_id = id
 }
 
-fn on_lazy_load(tree_id string, node_id string, mut w gui.Window) {
-	spawn fn [tree_id, node_id] (mut w gui.Window) {
+fn on_lazy_load(_tree_id string, node_id string, mut w gui.Window) {
+	spawn fn [node_id] (mut w gui.Window) {
 		time.sleep(800 * time.millisecond)
 		children := match node_id {
 			'remote_a' {
@@ -3120,7 +3118,7 @@ w.toast(gui.ToastCfg{
 | w.toast_dismiss(id) | Dismiss specific toast |
 | w.toast_dismiss_all() | Dismiss all toasts |'
 
-fn demo_toast(mut w gui.Window) gui.View {
+fn demo_toast(mut _w gui.Window) gui.View {
 	return gui.column(
 		spacing: gui.theme().spacing_small
 		content: [

--- a/examples/sidebar.v
+++ b/examples/sidebar.v
@@ -118,7 +118,7 @@ fn nav_item(icon string, label string) gui.View {
 				]
 			),
 		]
-		on_click:    fn [label] (_ &gui.Layout, mut _ gui.Event, mut _ gui.Window) {
+		on_click:    fn (_ &gui.Layout, mut _ gui.Event, mut _ gui.Window) {
 		}
 	)
 }

--- a/examples/tree_view.v
+++ b/examples/tree_view.v
@@ -28,10 +28,10 @@ fn on_select(id string, mut w gui.Window) {
 	app.selected_id = id
 }
 
-fn on_lazy_load(tree_id string, node_id string, mut w gui.Window) {
+fn on_lazy_load(_tree_id string, node_id string, mut w gui.Window) {
 	// Simulate async fetch: spawn a thread that sleeps then
 	// delivers children via queue_command.
-	spawn fn [tree_id, node_id] (mut w gui.Window) {
+	spawn fn [node_id] (mut w gui.Window) {
 		time.sleep(800 * time.millisecond)
 		children := match node_id {
 			'remote_a' {

--- a/inspector.v
+++ b/inspector.v
@@ -621,7 +621,7 @@ fn inspector_color_str(c Color) string {
 
 // inspector_apply_scroll_to scrolls the inspector panel to
 // reveal the pending scroll target, then clears it.
-fn inspector_apply_scroll_to(panel_h f32, mut w Window) {
+fn inspector_apply_scroll_to(_ f32, mut w Window) {
 	mut sm := state_map[string, string](mut w, ns_inspector, cap_inspector)
 	target := sm.get('scroll_to') or { return }
 	if target.len == 0 {

--- a/layout_sizing.v
+++ b/layout_sizing.v
@@ -324,7 +324,7 @@ fn distribute_space(mut layout Layout,
 // layout_widths arranges children horizontally. Only containers with an axis
 // are processed.
 fn layout_widths(mut layout Layout) {
-	padding := layout.shape.padding_width()
+	pad_w := layout.shape.padding_width()
 	if layout.shape.axis == .left_to_right { // along the axis
 		spacing := layout.spacing()
 		if layout.shape.sizing.width == .fixed {
@@ -332,7 +332,7 @@ fn layout_widths(mut layout Layout) {
 				layout_widths(mut child)
 			}
 		} else {
-			mut min_widths := padding + spacing
+			mut min_widths := pad_w + spacing
 			for mut child in layout.children {
 				layout_widths(mut child)
 				layout.shape.width += child.shape.width
@@ -340,19 +340,19 @@ fn layout_widths(mut layout Layout) {
 					// Wrap/overflow containers only need room for
 					// the widest single child; the respective layout
 					// pass handles the rest.
-					min_widths = f32_max(min_widths, child.shape.width + padding)
+					min_widths = f32_max(min_widths, child.shape.width + pad_w)
 				} else if !layout.shape.clip {
 					min_widths += child.shape.min_width
 				}
 			}
 
 			if !layout.shape.wrap && !layout.shape.overflow {
-				layout.shape.min_width = f32_max(min_widths, layout.shape.min_width + padding +
+				layout.shape.min_width = f32_max(min_widths, layout.shape.min_width + pad_w +
 					spacing)
 			} else {
 				layout.shape.min_width = f32_max(min_widths, layout.shape.min_width)
 			}
-			layout.shape.width += padding + spacing
+			layout.shape.width += pad_w + spacing
 
 			if layout.shape.max_width > 0 {
 				layout.shape.width = f32_min(layout.shape.max_width, layout.shape.width)
@@ -366,13 +366,13 @@ fn layout_widths(mut layout Layout) {
 		for mut child in layout.children {
 			layout_widths(mut child)
 			if layout.shape.sizing.width != .fixed {
-				layout.shape.width = f32_max(layout.shape.width, child.shape.width + padding)
+				layout.shape.width = f32_max(layout.shape.width, child.shape.width + pad_w)
 				// Clip containers hide overflow — children's min_width
 				// must not force the container wider.
 				if !layout.shape.clip {
 					layout.shape.min_width = f32_max(layout.shape.min_width,
 
-						child.shape.min_width + padding)
+						child.shape.min_width + pad_w)
 				}
 			}
 		}
@@ -388,7 +388,7 @@ fn layout_widths(mut layout Layout) {
 // layout_heights arranges children vertically. Only containers with an axis
 // are processed.
 fn layout_heights(mut layout Layout) {
-	padding := layout.shape.padding_height()
+	pad_h := layout.shape.padding_height()
 	if layout.shape.axis == .top_to_bottom { // along the axis
 		spacing := layout.spacing()
 		if layout.shape.sizing.height == .fixed {
@@ -396,16 +396,16 @@ fn layout_heights(mut layout Layout) {
 				layout_heights(mut child)
 			}
 		} else {
-			mut min_heights := padding + spacing
+			mut min_heights := pad_h + spacing
 			for mut child in layout.children {
 				layout_heights(mut child)
 				layout.shape.height += child.shape.height
 				min_heights += child.shape.min_height
 			}
 
-			layout.shape.min_height = f32_max(min_heights, layout.shape.min_height + padding +
-				spacing)
-			layout.shape.height += padding + spacing
+			layout.shape.min_height = f32_max(min_heights,
+				layout.shape.min_height + pad_h + spacing)
+			layout.shape.height += pad_h + spacing
 
 			if layout.shape.max_height > 0 {
 				layout.shape.height = f32_min(layout.shape.max_height, layout.shape.height)
@@ -422,9 +422,9 @@ fn layout_heights(mut layout Layout) {
 		for mut child in layout.children {
 			layout_heights(mut child)
 			if layout.shape.sizing.height != .fixed {
-				layout.shape.height = f32_max(layout.shape.height, child.shape.height + padding)
+				layout.shape.height = f32_max(layout.shape.height, child.shape.height + pad_h)
 				layout.shape.min_height = f32_max(layout.shape.min_height, child.shape.min_height +
-					padding)
+					pad_h)
 			}
 		}
 		if layout.shape.min_height > 0 {

--- a/list_core.v
+++ b/list_core.v
@@ -206,7 +206,7 @@ fn list_core_visible_range(item_count int, row_height f32, list_height f32, scro
 }
 
 // list_core_navigate maps a key code to a list navigation action.
-fn list_core_navigate(key KeyCode, item_count int, current int) ListCoreAction {
+fn list_core_navigate(key KeyCode, item_count int, _ int) ListCoreAction {
 	if item_count == 0 {
 		return .none
 	}

--- a/markdown_mermaid.v
+++ b/markdown_mermaid.v
@@ -78,8 +78,8 @@ fn mermaid_http_fetch(source string) !http.Response {
 	mut buf := []u8{cap: escaped.len}
 	for ech in escaped {
 		if ech < 0x20 || ech == 0x7f {
-			hex := '0000${ech:X}'
-			buf << '\\u${hex[hex.len - 4..]}'.bytes()
+			escaped_hex := '0000${ech:X}'
+			buf << '\\u${escaped_hex[escaped_hex.len - 4..]}'.bytes()
 		} else {
 			buf << ech
 		}

--- a/print_pdf.v
+++ b/print_pdf.v
@@ -390,14 +390,14 @@ fn pdf_draw_svg_clip_group(renderers []Renderer, idx int, mut out strings.Builde
 
 	for next_idx < renderers.len {
 		if renderers[next_idx] is DrawSvg {
-			svg := renderers[next_idx] as DrawSvg
-			if svg.clip_group == group {
-				if svg.is_clip_mask {
-					masks << svg
+			draw_svg := renderers[next_idx] as DrawSvg
+			if draw_svg.clip_group == group {
+				if draw_svg.is_clip_mask {
+					masks << draw_svg
 				} else {
 					content << PdfSvgIndexed{
 						idx: next_idx
-						svg: svg
+						svg: draw_svg
 					}
 				}
 				next_idx++
@@ -748,9 +748,9 @@ fn pdf_render_document(renderers []Renderer, source_width f32, source_height f32
 	page_width, page_height := print_page_size(job.paper, job.orientation)
 	header_h := print_header_footer_reserved_height(job.header)
 	footer_h := print_header_footer_reserved_height(job.footer)
-	content_width := page_width - job.margins.left - job.margins.right
-	content_height := page_height - job.margins.top - job.margins.bottom - header_h - footer_h
-	if content_width <= 0 || content_height <= 0 {
+	page_content_width := page_width - job.margins.left - job.margins.right
+	page_content_height := page_height - job.margins.top - job.margins.bottom - header_h - footer_h
+	if page_content_width <= 0 || page_content_height <= 0 {
 		return error('invalid page/margin configuration')
 	}
 	if source_width <= 0 || source_height <= 0 {
@@ -759,15 +759,15 @@ fn pdf_render_document(renderers []Renderer, source_width f32, source_height f32
 
 	mut scale := f32(1.0)
 	if job.scale_mode == .fit_to_page {
-		scale_x := content_width / source_width
-		scale_y := content_height / source_height
+		scale_x := page_content_width / source_width
+		scale_y := page_content_height / source_height
 		scale = f32_min(scale_x, scale_y)
 	}
 	if scale <= 0 {
 		return error('computed invalid scale')
 	}
 
-	page_source_height := content_height / scale
+	page_source_height := page_content_height / scale
 	mut page_count := 1
 	if job.paginate {
 		page_count = int(math.ceil(source_height / page_source_height))
@@ -823,9 +823,9 @@ fn pdf_render_document(renderers []Renderer, source_width f32, source_height f32
 			page_offset_y: if job.paginate { f32(idx) * page_source_height } else { f32(0.0) }
 		}
 		clip_x := job.margins.left
-		clip_y := page_height - (job.margins.top + header_h) - content_height
-		stream := pdf_page_stream(renderers, ctx, shading_refs, clip_x, clip_y, content_width,
-			content_height, job, idx + 1, page_count)
+		clip_y := page_height - (job.margins.top + header_h) - page_content_height
+		stream := pdf_page_stream(renderers, ctx, shading_refs, clip_x, clip_y, page_content_width,
+			page_content_height, job, idx + 1, page_count)
 		page_obj_idx := 3 + idx * 2
 		content_obj_idx := page_obj_idx + 1
 		page_obj :=

--- a/print_raster.v
+++ b/print_raster.v
@@ -92,7 +92,7 @@ fn (pr PrintPageRaster) destroy() {
 // render_page_to_pixels renders a page slice of the view
 // into a pixel buffer using the GPU pipeline. Must be
 // called within frame_fn, outside any active gfx pass.
-fn render_page_to_pixels(mut window Window, raster PrintPageRaster, source_width f32, page_source_height f32, page_offset_y f32) ![]u8 {
+fn render_page_to_pixels(mut window Window, raster PrintPageRaster, source_width f32, _ f32, page_offset_y f32) ![]u8 {
 	// Scale factor: logical source coords → raster pixels.
 	// Mirrors how normal rendering uses ui.scale to map
 	// logical coords to framebuffer pixels. All draw fns
@@ -179,23 +179,23 @@ fn jpeg_encode_rgba(pixels []u8, width int, height int, quality int, bgra bool) 
 	if pixels.len < width * height * 4 {
 		return error('pixel buffer too small')
 	}
-	mut rgb := []u8{len: width * height * 3}
+	mut rgb_pixels := []u8{len: width * height * 3}
 	for i := 0; i < width * height; i++ {
 		si := i * 4
 		di := i * 3
 		if bgra {
-			rgb[di] = pixels[si + 2] // R from BGRA
-			rgb[di + 1] = pixels[si + 1] // G
-			rgb[di + 2] = pixels[si] // B from BGRA
+			rgb_pixels[di] = pixels[si + 2] // R from BGRA
+			rgb_pixels[di + 1] = pixels[si + 1] // G
+			rgb_pixels[di + 2] = pixels[si] // B from BGRA
 		} else {
-			rgb[di] = pixels[si] // R from RGBA
-			rgb[di + 1] = pixels[si + 1] // G
-			rgb[di + 2] = pixels[si + 2] // B from RGBA
+			rgb_pixels[di] = pixels[si] // R from RGBA
+			rgb_pixels[di + 1] = pixels[si + 1] // G
+			rgb_pixels[di + 2] = pixels[si + 2] // B from RGBA
 		}
 	}
 	mut wctx := JpegWriteContext{}
 	result := C.stbi_write_jpg_to_func(jpeg_write_callback, voidptr(&wctx), width, height, 3,
-		rgb.data, quality)
+		rgb_pixels.data, quality)
 	if result == 0 {
 		return error('JPEG encoding failed')
 	}
@@ -209,24 +209,24 @@ fn pdf_render_document_raster(mut window Window, source_width f32, source_height
 	page_width, page_height := print_page_size(job.paper, job.orientation)
 	header_h := print_header_footer_reserved_height(job.header)
 	footer_h := print_header_footer_reserved_height(job.footer)
-	content_width := page_width - job.margins.left - job.margins.right
-	content_height := page_height - job.margins.top - job.margins.bottom - header_h - footer_h
+	page_content_width := page_width - job.margins.left - job.margins.right
+	page_content_height := page_height - job.margins.top - job.margins.bottom - header_h - footer_h
 
-	if content_width <= 0 || content_height <= 0 {
+	if page_content_width <= 0 || page_content_height <= 0 {
 		return error('invalid page/margin configuration')
 	}
 
 	// Source-space page height via scale.
 	mut scale := f32(1.0)
 	if job.scale_mode == .fit_to_page {
-		scale_x := content_width / source_width
-		scale_y := content_height / source_height
+		scale_x := page_content_width / source_width
+		scale_y := page_content_height / source_height
 		scale = f32_min(scale_x, scale_y)
 	}
 	if scale <= 0 {
 		return error('computed invalid scale')
 	}
-	page_source_height := content_height / scale
+	page_source_height := page_content_height / scale
 
 	mut page_count := 1
 	if job.paginate {
@@ -249,8 +249,8 @@ fn pdf_render_document_raster(mut window Window, source_width f32, source_height
 	// PDF image placement dimensions. For fit_to_page the
 	// image is scaled to fit within the content area. For
 	// actual_size the image fills the content area.
-	mut place_w := content_width
-	mut place_h := content_height
+	mut place_w := page_content_width
+	mut place_h := page_content_height
 	if job.scale_mode == .fit_to_page {
 		place_w = source_width * scale
 		place_h = page_source_height * scale

--- a/render_draw_dispatch.v
+++ b/render_draw_dispatch.v
@@ -165,9 +165,10 @@ fn renderers_draw(mut window Window) {
 					continue
 				}
 				if candidate is DrawSvg {
-					svg := candidate
-					if svg.clip_group == 0 && svg.vertex_colors.len == 0 && svg.color == color
-						&& svg.x == x && svg.y == y && svg.scale == scale {
+					draw_svg := candidate
+					if draw_svg.clip_group == 0 && draw_svg.vertex_colors.len == 0
+						&& draw_svg.color == color && draw_svg.x == x && draw_svg.y == y
+						&& draw_svg.scale == scale {
 						i++
 						continue
 					}
@@ -294,9 +295,9 @@ fn draw_clipped_svg_group(renderers []Renderer, idx int, mut window Window) int 
 			continue
 		}
 		if candidate is DrawSvg {
-			svg := candidate
-			if svg.clip_group == group {
-				if svg.is_clip_mask {
+			draw_svg := candidate
+			if draw_svg.clip_group == group {
+				if draw_svg.is_clip_mask {
 					has_mask = true
 				} else {
 					has_content = true

--- a/render_filters.v
+++ b/render_filters.v
@@ -139,11 +139,11 @@ fn process_svg_filters(mut window Window) {
 			// Compute screen-space bbox with blur padding
 			scale := begin.scale
 			ui_scale := window.ui.scale
-			padding := filter.std_dev * 3.0 * scale
-			bbox_x := (begin.x + fg.bbox[0] * scale - padding) * ui_scale
-			bbox_y := (begin.y + fg.bbox[1] * scale - padding) * ui_scale
-			bbox_w := (fg.bbox[2] * scale + padding * 2) * ui_scale
-			bbox_h := (fg.bbox[3] * scale + padding * 2) * ui_scale
+			blur_pad := filter.std_dev * 3.0 * scale
+			bbox_x := (begin.x + fg.bbox[0] * scale - blur_pad) * ui_scale
+			bbox_y := (begin.y + fg.bbox[1] * scale - blur_pad) * ui_scale
+			bbox_w := (fg.bbox[2] * scale + blur_pad * 2) * ui_scale
+			bbox_h := (fg.bbox[3] * scale + blur_pad * 2) * ui_scale
 
 			tex_dims := filter_texture_dims_from_bbox(bbox_w, bbox_h, max_tex_size)
 			if !tex_dims.valid {

--- a/render_gradient.v
+++ b/render_gradient.v
@@ -34,12 +34,12 @@ pub fn draw_blur_rect(x f32, y f32, w f32, h f32, radius f32, blur f32, c gg.Col
 	}
 
 	scale := window.ui.scale
-	padding := blur * 1.5
+	blur_pad := blur * 1.5
 
-	sx := (x - padding) * scale
-	sy := (y - padding) * scale
-	sw := (w + padding * 2) * scale
-	sh := (h + padding * 2) * scale
+	sx := (x - blur_pad) * scale
+	sy := (y - blur_pad) * scale
+	sw := (w + blur_pad * 2) * scale
+	sh := (h + blur_pad * 2) * scale
 
 	r := radius * scale
 	b := blur * scale

--- a/render_layout_tree.v
+++ b/render_layout_tree.v
@@ -167,7 +167,7 @@ fn render_shape_inner(mut shape Shape, parent_color Color, clip DrawClip, mut wi
 // One complication is the title text that is drawn in the upper left corner of the rectangle.
 // At some point, it should be moved to the container logic, along with some layout amend logic.
 // Honestly, it was more expedient to put it here.
-fn render_container(mut shape Shape, parent_color Color, clip DrawClip, mut window Window) {
+fn render_container(mut shape Shape, _ Color, clip DrawClip, mut window Window) {
 	fx := shape.fx
 	has_fx := fx != unsafe { nil }
 	if has_fx && fx.shadow != unsafe { nil } && fx.shadow.color.a > 0 && fx.shadow.blur_radius > 0 {
@@ -376,7 +376,7 @@ fn render_image(mut shape Shape, clip DrawClip, mut window Window) {
 		shape.disabled = true
 		return
 	}
-	image := window.load_image(shape.resource) or {
+	loaded_image := window.load_image(shape.resource) or {
 		log.error('${@FILE_LINE} > ${err.msg()}')
 		emit_error_placeholder(shape.x, shape.y, shape.width, shape.height, mut window)
 		return
@@ -386,7 +386,7 @@ fn render_image(mut shape Shape, clip DrawClip, mut window Window) {
 		y:           shape.y
 		w:           shape.width
 		h:           shape.height
-		img:         image
+		img:         loaded_image
 		clip_radius: window.clip_radius
 	}, mut window)
 }

--- a/render_text.v
+++ b/render_text.v
@@ -395,7 +395,7 @@ fn draw_text_selection(mut window Window, params DrawTextSelectionParams) {
 // input_cursor_on is read live here — never captured in a closure — so the
 // blink animation (render-only path) toggles it and triggers a re-render
 // without rebuilding the layout tree.
-fn render_cursor(shape &Shape, clip DrawClip, mut window Window) {
+fn render_cursor(shape &Shape, _ DrawClip, mut window Window) {
 	if window.is_focus(shape.id_focus) && shape.shape_type == .text
 		&& window.view_state.input_cursor_on {
 		input_state := state_map[u32, InputState](mut window, ns_input, cap_many).get(shape.id_focus) or {

--- a/shaders.v
+++ b/shaders.v
@@ -764,12 +764,12 @@ pub fn draw_shadow_rect(x f32, y f32, w f32, h f32, radius f32, blur f32, c gg.C
 	scale := window.ui.scale
 	// We draw a larger quad to accommodate the blur
 	// Padding = blur radius * 1.5 to be safe
-	padding := blur * 1.5
+	blur_pad := blur * 1.5
 
-	sx := (x - padding) * scale
-	sy := (y - padding) * scale
-	sw := (w + padding * 2) * scale
-	sh := (h + padding * 2) * scale
+	sx := (x - blur_pad) * scale
+	sy := (y - blur_pad) * scale
+	sw := (w + blur_pad * 2) * scale
+	sh := (h + blur_pad * 2) * scale
 
 	r := radius * scale
 	b := blur * scale

--- a/svg/shapes.v
+++ b/svg/shapes.v
@@ -197,7 +197,7 @@ fn parse_ellipse_element(elem string) ?VectorPath {
 }
 
 // ellipse_to_path converts an ellipse to a path using 4 cubic beziers
-fn ellipse_to_path(cx f32, cy f32, rx f32, ry f32, elem string, fill string, s ElementStyle) VectorPath {
+fn ellipse_to_path(cx f32, cy f32, rx f32, ry f32, _ string, fill string, s ElementStyle) VectorPath {
 	// Approximate circle with 4 cubic beziers (kappa = 4*(sqrt(2)-1)/3)
 	k := f32(0.5522847498)
 	kx := rx * k

--- a/theme.v
+++ b/theme.v
@@ -17,7 +17,7 @@ pub fn theme_maker(cfg &ThemeCfg) Theme {
 		}
 	}
 
-	theme := Theme{
+	built_theme := Theme{
 		cfg:              *cfg
 		name:             cfg.name
 		color_background: cfg.color_background
@@ -528,105 +528,105 @@ pub fn theme_maker(cfg &ThemeCfg) Theme {
 		scroll_delta_page: cfg.scroll_delta_page
 	}
 
-	variants := font_variants(theme.text_style)
+	variants := font_variants(built_theme.text_style)
 	normal := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		family: variants.normal
 	}
 	bold := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		family: variants.bold
 	}
 	italic := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		family: variants.italic
 	}
 	bold_italic := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		typeface: .bold_italic
 	}
 	mono := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		family: variants.mono
 	}
 	icon := TextStyle{
-		...theme.text_style
+		...built_theme.text_style
 		family: icon_font_name
 	}
 
 	return Theme{
-		...theme
-		n1: make_style(normal, theme.size_text_x_large)
-		n2: make_style(normal, theme.size_text_large)
-		n3: theme.text_style
-		n4: make_style(normal, theme.size_text_small)
-		n5: make_style(normal, theme.size_text_x_small)
-		n6: make_style(normal, theme.size_text_tiny)
+		...built_theme
+		n1: make_style(normal, built_theme.size_text_x_large)
+		n2: make_style(normal, built_theme.size_text_large)
+		n3: built_theme.text_style
+		n4: make_style(normal, built_theme.size_text_small)
+		n5: make_style(normal, built_theme.size_text_x_small)
+		n6: make_style(normal, built_theme.size_text_tiny)
 		// Bold
-		b1: make_style(bold, theme.size_text_x_large)
-		b2: make_style(bold, theme.size_text_large)
-		b3: make_style(bold, theme.size_text_medium)
-		b4: make_style(bold, theme.size_text_small)
-		b5: make_style(bold, theme.size_text_x_small)
-		b6: make_style(bold, theme.size_text_tiny)
+		b1: make_style(bold, built_theme.size_text_x_large)
+		b2: make_style(bold, built_theme.size_text_large)
+		b3: make_style(bold, built_theme.size_text_medium)
+		b4: make_style(bold, built_theme.size_text_small)
+		b5: make_style(bold, built_theme.size_text_x_small)
+		b6: make_style(bold, built_theme.size_text_tiny)
 		// Italic
-		i1: make_style(italic, theme.size_text_x_large)
-		i2: make_style(italic, theme.size_text_large)
-		i3: make_style(italic, theme.size_text_medium)
-		i4: make_style(italic, theme.size_text_small)
-		i5: make_style(italic, theme.size_text_x_small)
-		i6: make_style(italic, theme.size_text_tiny)
+		i1: make_style(italic, built_theme.size_text_x_large)
+		i2: make_style(italic, built_theme.size_text_large)
+		i3: make_style(italic, built_theme.size_text_medium)
+		i4: make_style(italic, built_theme.size_text_small)
+		i5: make_style(italic, built_theme.size_text_x_small)
+		i6: make_style(italic, built_theme.size_text_tiny)
 		// Bold+Italic
-		bi1: make_style(bold_italic, theme.size_text_x_large)
-		bi2: make_style(bold_italic, theme.size_text_large)
-		bi3: make_style(bold_italic, theme.size_text_medium)
-		bi4: make_style(bold_italic, theme.size_text_small)
-		bi5: make_style(bold_italic, theme.size_text_x_small)
-		bi6: make_style(bold_italic, theme.size_text_tiny)
+		bi1: make_style(bold_italic, built_theme.size_text_x_large)
+		bi2: make_style(bold_italic, built_theme.size_text_large)
+		bi3: make_style(bold_italic, built_theme.size_text_medium)
+		bi4: make_style(bold_italic, built_theme.size_text_small)
+		bi5: make_style(bold_italic, built_theme.size_text_x_small)
+		bi6: make_style(bold_italic, built_theme.size_text_tiny)
 		// Mono
-		m1: make_style(mono, theme.size_text_x_large + 1)
-		m2: make_style(mono, theme.size_text_large + 1)
-		m3: make_style(mono, theme.size_text_medium + 1)
-		m4: make_style(mono, theme.size_text_small + 1)
-		m5: make_style(mono, theme.size_text_x_small + 1)
-		m6: make_style(mono, theme.size_text_tiny + 1)
+		m1: make_style(mono, built_theme.size_text_x_large + 1)
+		m2: make_style(mono, built_theme.size_text_large + 1)
+		m3: make_style(mono, built_theme.size_text_medium + 1)
+		m4: make_style(mono, built_theme.size_text_small + 1)
+		m5: make_style(mono, built_theme.size_text_x_small + 1)
+		m6: make_style(mono, built_theme.size_text_tiny + 1)
 		// Icon Font
-		icon1: make_style(icon, theme.size_text_x_large)
-		icon2: make_style(icon, theme.size_text_large)
-		icon3: make_style(icon, theme.size_text_medium)
-		icon4: make_style(icon, theme.size_text_small)
-		icon5: make_style(icon, theme.size_text_x_small)
-		icon6: make_style(icon, theme.size_text_tiny)
+		icon1: make_style(icon, built_theme.size_text_x_large)
+		icon2: make_style(icon, built_theme.size_text_large)
+		icon3: make_style(icon, built_theme.size_text_medium)
+		icon4: make_style(icon, built_theme.size_text_small)
+		icon5: make_style(icon, built_theme.size_text_x_small)
+		icon6: make_style(icon, built_theme.size_text_tiny)
 
 		menubar_style: MenubarStyle{
-			...theme.menubar_style
+			...built_theme.menubar_style
 			text_style_subtitle: TextStyle{
 				...bold
-				size: theme.size_text_small
+				size: built_theme.size_text_small
 			}
 		}
 		// sel
 		select_style: SelectStyle{
-			...theme.select_style
+			...built_theme.select_style
 			subheading_style: TextStyle{
 				...bold
 			}
 		}
 		// listbox
 		list_box_style:   ListBoxStyle{
-			...theme.list_box_style
+			...built_theme.list_box_style
 			subheading_style: TextStyle{
 				...bold
 			}
 		}
 		data_grid_style:  DataGridStyle{
-			...theme.data_grid_style
+			...built_theme.data_grid_style
 			text_style:        normal
 			text_style_header: bold
 			text_style_filter: normal
 		}
 		tab_style:        TabStyle{
-			...theme.tab_style
+			...built_theme.tab_style
 			text_style:          normal
 			text_style_selected: bold
 			text_style_disabled: TextStyle{
@@ -640,7 +640,7 @@ pub fn theme_maker(cfg &ThemeCfg) Theme {
 			}
 		}
 		breadcrumb_style: BreadcrumbStyle{
-			...theme.breadcrumb_style
+			...built_theme.breadcrumb_style
 			text_style:           normal
 			text_style_selected:  bold
 			text_style_disabled:  TextStyle{
@@ -664,29 +664,29 @@ pub fn theme_maker(cfg &ThemeCfg) Theme {
 			text_style_icon:      TextStyle{
 				...normal
 				family: icon_font_name
-				size:   theme.size_text_medium
+				size:   built_theme.size_text_medium
 			}
 		}
 		// markdown
 		markdown_style: MarkdownStyle{
 			text:                normal
-			h1:                  make_style(bold, theme.size_text_x_large)
-			h2:                  make_style(bold, theme.size_text_large)
-			h3:                  make_style(bold, theme.size_text_medium)
-			h4:                  make_style(bold, theme.size_text_small)
-			h5:                  make_style(bold, theme.size_text_x_small)
-			h6:                  make_style(bold, theme.size_text_tiny)
-			bold:                make_style(bold, theme.size_text_medium)
-			italic:              make_style(italic, theme.size_text_medium)
-			code:                make_style(mono, theme.size_text_medium + 1)
+			h1:                  make_style(bold, built_theme.size_text_x_large)
+			h2:                  make_style(bold, built_theme.size_text_large)
+			h3:                  make_style(bold, built_theme.size_text_medium)
+			h4:                  make_style(bold, built_theme.size_text_small)
+			h5:                  make_style(bold, built_theme.size_text_x_small)
+			h6:                  make_style(bold, built_theme.size_text_tiny)
+			bold:                make_style(bold, built_theme.size_text_medium)
+			italic:              make_style(italic, built_theme.size_text_medium)
+			code:                make_style(mono, built_theme.size_text_medium + 1)
 			code_block_bg:       rgb(40, 44, 52)
-			code_keyword_color:  theme.color_select
+			code_keyword_color:  built_theme.color_select
 			code_string_color:   rgb(152, 195, 121)
 			code_number_color:   rgb(209, 154, 102)
-			code_comment_color:  theme.color_border
+			code_comment_color:  built_theme.color_border
 			code_operator_color: normal.color
-			hr_color:            theme.color_border
-			link_color:          theme.color_select
+			hr_color:            built_theme.color_border
+			link_color:          built_theme.color_select
 		}
 	}
 }

--- a/view_container.v
+++ b/view_container.v
@@ -377,9 +377,9 @@ pub fn circle(cfg ContainerCfg) View {
 		cfg.axis = .top_to_bottom
 		cfg.name = if cfg.name.is_blank() { 'circle' } else { cfg.name }
 	}
-	mut circle := container(cfg) as ContainerView
-	circle.shape_type = .circle
-	return circle
+	mut circle_view := container(cfg) as ContainerView
+	circle_view.shape_type = .circle
+	return circle_view
 }
 
 // make_a11y returns the direct AccessInfo if set, otherwise
@@ -487,7 +487,7 @@ fn invisible_container_view() ContainerView {
 	}
 }
 
-fn (cv &ContainerView) add_group_box_title(mut w Window, mut children []gui.Layout) {
+fn (cv &ContainerView) add_group_box_title(mut w Window, mut children []Layout) {
 	if cv.title.len == 0 {
 		return
 	}
@@ -506,11 +506,11 @@ fn (cv &ContainerView) add_group_box_title(mut w Window, mut children []gui.Layo
 	}
 
 	cfg := text_style.to_vglyph_cfg()
-	text_width := w.text_system.text_width(cv.title, cfg) or { 0 }
+	title_text_width := w.text_system.text_width(cv.title, cfg) or { 0 }
 	metrics := w.text_system.font_metrics(cfg) or { vglyph.TextMetrics{} }
 
 	offset := metrics.ascender - metrics.descender
-	padding := f32(5)
+	title_pad := f32(5)
 
 	// 1. Eraser Node (hides the border)
 	parent_bg := cv.title_bg
@@ -518,7 +518,7 @@ fn (cv &ContainerView) add_group_box_title(mut w Window, mut children []gui.Layo
 	children << Layout{
 		shape: &Shape{
 			shape_type:   .rectangle
-			width:        text_width + padding + padding - 1
+			width:        title_text_width + title_pad + title_pad - 1
 			height:       metrics.ascender + metrics.descender
 			x:            20
 			y:            -offset
@@ -532,10 +532,10 @@ fn (cv &ContainerView) add_group_box_title(mut w Window, mut children []gui.Layo
 	children << Layout{
 		shape: &Shape{
 			shape_type: .text
-			x:          20 + padding
+			x:          20 + title_pad
 			y:          -offset
 			color:      text_color
-			width:      text_width
+			width:      title_text_width
 			height:     metrics.ascender + metrics.descender // Logical height
 			float:      true
 			tc:         &ShapeTextConfig{

--- a/view_data_grid.v
+++ b/view_data_grid.v
@@ -592,12 +592,12 @@ pub fn (mut window Window) data_grid(cfg DataGridCfg) View {
 	)
 }
 
-fn data_grid_presentation(cfg DataGridCfg, columns []gui.GridColumnCfg) DataGridPresentation {
+fn data_grid_presentation(cfg DataGridCfg, columns []GridColumnCfg) DataGridPresentation {
 	return data_grid_presentation_rows(cfg, columns, data_grid_visible_row_indices(cfg.rows.len,
 		[]int{}))
 }
 
-fn data_grid_cached_presentation(cfg DataGridCfg, columns []gui.GridColumnCfg, row_indices []int, mut window Window) DataGridPresentation {
+fn data_grid_cached_presentation(cfg DataGridCfg, columns []GridColumnCfg, row_indices []int, mut window Window) DataGridPresentation {
 	group_cols := data_grid_group_columns(cfg.group_by, columns)
 	value_cols := data_grid_presentation_value_cols(group_cols, cfg.aggregates)
 	signature := data_grid_presentation_signature(cfg, columns, row_indices, group_cols, value_cols)
@@ -630,7 +630,7 @@ fn data_grid_cached_presentation(cfg DataGridCfg, columns []gui.GridColumnCfg, r
 	return presentation
 }
 
-fn data_grid_presentation_signature(cfg DataGridCfg, columns []gui.GridColumnCfg, row_indices []int, group_cols []string, value_cols []string) u64 {
+fn data_grid_presentation_signature(cfg DataGridCfg, columns []GridColumnCfg, row_indices []int, group_cols []string, value_cols []string) u64 {
 	mut hash := data_grid_fnv64_offset
 	visible_indices := data_grid_visible_row_indices(cfg.rows.len, row_indices)
 	group_titles := data_grid_group_titles(columns)
@@ -660,8 +660,8 @@ fn data_grid_presentation_signature(cfg DataGridCfg, columns []gui.GridColumnCfg
 	detail_enabled := cfg.on_detail_row_view != unsafe { nil }
 	hash = data_grid_fnv64_byte(hash, if detail_enabled { `1` } else { `0` })
 	for row_idx in visible_indices {
-		row := cfg.rows[row_idx]
-		row_id := data_grid_row_id(row, row_idx)
+		data_row := cfg.rows[row_idx]
+		row_id := data_grid_row_id(data_row, row_idx)
 		hash = data_grid_fnv64_byte(hash, 0x1e)
 		hash = data_grid_fnv64_u64(hash, u64(row_idx))
 		hash = data_grid_fnv64_byte(hash, 0x1f)
@@ -676,7 +676,7 @@ fn data_grid_presentation_signature(cfg DataGridCfg, columns []gui.GridColumnCfg
 			hash = data_grid_fnv64_byte(hash, 0x1f)
 			hash = data_grid_fnv64_str(hash, col_id)
 			hash = data_grid_fnv64_byte(hash, `=`)
-			hash = data_grid_fnv64_str(hash, row.cells[col_id] or { '' })
+			hash = data_grid_fnv64_str(hash, data_row.cells[col_id] or { '' })
 		}
 	}
 	return hash
@@ -709,7 +709,7 @@ fn data_grid_presentation_value_cols(group_cols []string, aggregates []GridAggre
 // expansion rows are interleaved after their parent data
 // row. data_to_display maps data row index → display index
 // for scroll-into-view.
-fn data_grid_presentation_rows(cfg DataGridCfg, columns []gui.GridColumnCfg, row_indices []int) DataGridPresentation {
+fn data_grid_presentation_rows(cfg DataGridCfg, columns []GridColumnCfg, row_indices []int) DataGridPresentation {
 	visible_indices := data_grid_visible_row_indices(cfg.rows.len, row_indices)
 	group_cols := data_grid_group_columns(cfg.group_by, columns)
 	group_ranges := if group_cols.len > 0 && visible_indices.len > 0 {
@@ -721,19 +721,19 @@ fn data_grid_presentation_rows(cfg DataGridCfg, columns []gui.GridColumnCfg, row
 		group_ranges)
 }
 
-fn data_grid_presentation_rows_with_group_ranges(cfg DataGridCfg, columns []gui.GridColumnCfg, visible_indices []int, group_cols []string, group_ranges map[string]int) DataGridPresentation {
+fn data_grid_presentation_rows_with_group_ranges(cfg DataGridCfg, columns []GridColumnCfg, visible_indices []int, group_cols []string, group_ranges map[string]int) DataGridPresentation {
 	mut rows := []DataGridDisplayRow{cap: cfg.rows.len + 8}
 	mut data_to_display := map[int]int{}
 	if group_cols.len == 0 || visible_indices.len == 0 {
 		for row_idx in visible_indices {
-			row := cfg.rows[row_idx]
+			data_row := cfg.rows[row_idx]
 			data_to_display[row_idx] = rows.len
 			rows << DataGridDisplayRow{
 				kind:         .data
 				data_row_idx: row_idx
 			}
 			if cfg.on_detail_row_view != unsafe { nil }
-				&& data_grid_detail_row_expanded(cfg, data_grid_row_id(row, row_idx)) {
+				&& data_grid_detail_row_expanded(cfg, data_grid_row_id(data_row, row_idx)) {
 				rows << DataGridDisplayRow{
 					kind:         .detail
 					data_row_idx: row_idx
@@ -751,10 +751,10 @@ fn data_grid_presentation_rows_with_group_ranges(cfg DataGridCfg, columns []gui.
 	mut has_prev := false
 
 	for local_idx, row_idx in visible_indices {
-		row := cfg.rows[row_idx]
+		data_row := cfg.rows[row_idx]
 		mut values := []string{cap: group_cols.len}
 		for col_id in group_cols {
-			values << row.cells[col_id] or { '' }
+			values << data_row.cells[col_id] or { '' }
 		}
 		mut change_depth := -1
 		if !has_prev {
@@ -792,7 +792,7 @@ fn data_grid_presentation_rows_with_group_ranges(cfg DataGridCfg, columns []gui.
 			data_row_idx: row_idx
 		}
 		if cfg.on_detail_row_view != unsafe { nil }
-			&& data_grid_detail_row_expanded(cfg, data_grid_row_id(row, row_idx)) {
+			&& data_grid_detail_row_expanded(cfg, data_grid_row_id(data_row, row_idx)) {
 			rows << DataGridDisplayRow{
 				kind:         .detail
 				data_row_idx: row_idx
@@ -808,7 +808,7 @@ fn data_grid_presentation_rows_with_group_ranges(cfg DataGridCfg, columns []gui.
 	}
 }
 
-fn data_grid_group_columns(group_by []string, columns []gui.GridColumnCfg) []string {
+fn data_grid_group_columns(group_by []string, columns []GridColumnCfg) []string {
 	if group_by.len == 0 {
 		return []
 	}
@@ -830,7 +830,7 @@ fn data_grid_group_columns(group_by []string, columns []gui.GridColumnCfg) []str
 	return cols
 }
 
-fn data_grid_group_titles(columns []gui.GridColumnCfg) map[string]string {
+fn data_grid_group_titles(columns []GridColumnCfg) map[string]string {
 	mut titles := map[string]string{}
 	for col in columns {
 		if col.id.len == 0 {
@@ -851,7 +851,7 @@ fn data_grid_group_range_key(depth int, start_idx int) string {
 // depths D..max, then opens new ranges. Key format is
 // "depth:start_idx". Accepts full rows array + indices to
 // avoid copying row structs.
-fn data_grid_group_ranges(rows []gui.GridRow, indices []int, group_cols []string) map[string]int {
+fn data_grid_group_ranges(rows []GridRow, indices []int, group_cols []string) map[string]int {
 	mut ranges := map[string]int{}
 	if indices.len == 0 || group_cols.len == 0 {
 		return ranges
@@ -864,10 +864,10 @@ fn data_grid_group_ranges(rows []gui.GridRow, indices []int, group_cols []string
 	}
 
 	for i in 1 .. indices.len {
-		row := rows[indices[i]]
+		data_row := rows[indices[i]]
 		mut change_depth := -1
 		for depth, col_id in group_cols {
-			value := row.cells[col_id] or { '' }
+			value := data_row.cells[col_id] or { '' }
 			if value != values[depth] {
 				change_depth = depth
 				break
@@ -889,7 +889,7 @@ fn data_grid_group_ranges(rows []gui.GridRow, indices []int, group_cols []string
 		for dep in change_depth .. group_cols.len {
 			col_id := group_cols[dep]
 			starts[dep] = i
-			values[dep] = row.cells[col_id] or { '' }
+			values[dep] = data_row.cells[col_id] or { '' }
 		}
 	}
 
@@ -930,7 +930,7 @@ fn data_grid_aggregate_label(agg GridAggregateCfg) string {
 	return '${agg.op.str()} ${agg.col_id}'
 }
 
-fn data_grid_aggregate_value(rows []gui.GridRow, start_idx int, end_idx int, agg GridAggregateCfg) ?string {
+fn data_grid_aggregate_value(rows []GridRow, start_idx int, end_idx int, agg GridAggregateCfg) ?string {
 	if agg.op == .count {
 		return (end_idx - start_idx + 1).str()
 	}
@@ -990,14 +990,14 @@ fn data_grid_parse_number(value string) ?f64 {
 }
 
 fn data_grid_format_number(value f64) string {
-	mut text := '${value:.4f}'
-	for text.contains('.') && text.ends_with('0') {
-		text = text[..text.len - 1]
+	mut formatted := '${value:.4f}'
+	for formatted.contains('.') && formatted.ends_with('0') {
+		formatted = formatted[..formatted.len - 1]
 	}
-	if text.ends_with('.') {
-		text = text[..text.len - 1]
+	if formatted.ends_with('.') {
+		formatted = formatted[..formatted.len - 1]
 	}
-	return text
+	return formatted
 }
 
 fn data_grid_row_id(row GridRow, idx int) string {
@@ -1086,7 +1086,7 @@ fn data_grid_row_height(cfg DataGridCfg, mut window Window) f32 {
 	return font_h + cfg.padding_cell.height() + cfg.size_border
 }
 
-fn data_grid_static_top_height(cfg DataGridCfg, row_height f32, chooser_open bool, include_header bool) f32 {
+fn data_grid_static_top_height(cfg DataGridCfg, _ f32, chooser_open bool, include_header bool) f32 {
 	mut top := f32(0)
 	if cfg.show_column_chooser {
 		top += data_grid_column_chooser_height(cfg, chooser_open)

--- a/view_data_grid_crud.v
+++ b/view_data_grid_crud.v
@@ -26,7 +26,7 @@ fn data_grid_crud_row_delete_enabled(cfg DataGridCfg, has_source bool, caps Grid
 
 // col_ids: pre-sorted column ID list. When non-empty,
 // avoids per-row .keys() + .sort() allocations.
-fn data_grid_rows_signature(rows []gui.GridRow, col_ids []string) u64 {
+fn data_grid_rows_signature(rows []GridRow, col_ids []string) u64 {
 	if rows.len == 0 {
 		return u64(0)
 	}
@@ -60,7 +60,7 @@ fn data_grid_rows_signature(rows []gui.GridRow, col_ids []string) u64 {
 	return h
 }
 
-fn data_grid_rows_id_signature(rows []gui.GridRow) u64 {
+fn data_grid_rows_id_signature(rows []GridRow) u64 {
 	if rows.len == 0 {
 		return u64(0)
 	}
@@ -241,11 +241,11 @@ fn data_grid_crud_add_row(grid_id string, columns []GridColumnCfg, on_selection_
 	}
 	state.next_draft_seq++
 	draft_id := '__draft_${grid_id}_${state.next_draft_seq}'
-	row := GridRow{
+	draft_row := GridRow{
 		id:    draft_id
 		cells: data_grid_crud_default_cells(columns)
 	}
-	state.working_rows.insert(0, row)
+	state.working_rows.insert(0, draft_row)
 	state.draft_row_ids[draft_id] = true
 	state.dirty_row_ids[draft_id] = true
 	state.save_error = ''
@@ -362,7 +362,7 @@ fn data_grid_selection_remove_ids(selection GridSelection, remove_ids map[string
 // mutation lists: new draft rows (create), dirty non-draft rows
 // with per-cell deltas (update), and deleted row IDs.
 // committed_map enables O(1) lookup of previous cell values.
-fn data_grid_crud_build_payload(state DataGridCrudState) ([]gui.GridRow, []gui.GridRow, []gui.GridCellEdit, []string) {
+fn data_grid_crud_build_payload(state DataGridCrudState) ([]GridRow, []GridRow, []GridCellEdit, []string) {
 	mut create_rows := []GridRow{}
 	mut update_rows := []GridRow{}
 	mut update_edits := []GridCellEdit{}
@@ -417,7 +417,7 @@ fn data_grid_crud_build_payload(state DataGridCrudState) ([]gui.GridRow, []gui.G
 // server-assigned rows. The source MUST return `created` in the
 // same order as the input `create_rows`; mismatched order causes
 // draft IDs to persist silently. Returns (id_map, error_msg).
-fn data_grid_crud_replace_created_rows(mut rows []gui.GridRow, create_rows []gui.GridRow, created []gui.GridRow) (map[string]string, string) {
+fn data_grid_crud_replace_created_rows(mut rows []GridRow, create_rows []GridRow, created []GridRow) (map[string]string, string) {
 	mut replace := map[string]string{}
 	if create_rows.len == 0 || created.len == 0 {
 		if create_rows.len > 0 && created.len == 0 {
@@ -614,7 +614,7 @@ fn data_grid_crud_save(ctx DataGridCrudSaveContext, mut e Event, mut w Window) {
 // Executes create/update/delete mutations sequentially on a
 // spawned thread. Returns a result struct for main-thread
 // application via queue_command.
-fn data_grid_crud_exec_mutations(mut source DataGridDataSource, grid_id string, query GridQueryState, create_rows []gui.GridRow, update_rows []gui.GridRow, update_edits []gui.GridCellEdit, delete_ids []string) DataGridCrudMutationResult {
+fn data_grid_crud_exec_mutations(mut source DataGridDataSource, grid_id string, query GridQueryState, create_rows []GridRow, update_rows []GridRow, update_edits []GridCellEdit, delete_ids []string) DataGridCrudMutationResult {
 	mut row_count := ?int(none)
 	mut created := []GridRow{}
 	if create_rows.len > 0 {
@@ -680,7 +680,7 @@ fn data_grid_crud_exec_mutations(mut source DataGridDataSource, grid_id string, 
 
 // Applied on main thread via queue_command after async
 // mutations complete (success or failure).
-fn data_grid_crud_apply_save_result(grid_id string, result DataGridCrudMutationResult, snapshot_rows []gui.GridRow, on_crud_error fn (msg string, mut e Event, mut w Window), on_rows_change fn (rows_ []gui.GridRow, mut e Event, mut w Window), selection GridSelection, on_selection_change fn (sel GridSelection, mut e Event, mut w Window), focus_id u32, mut w Window) {
+fn data_grid_crud_apply_save_result(grid_id string, result DataGridCrudMutationResult, snapshot_rows []GridRow, on_crud_error fn (msg string, mut e Event, mut w Window), on_rows_change fn (rows_ []GridRow, mut e Event, mut w Window), selection GridSelection, on_selection_change fn (sel GridSelection, mut e Event, mut w Window), focus_id u32, mut w Window) {
 	mut e := Event{}
 	if result.err_msg.len > 0 {
 		data_grid_crud_restore_on_error(grid_id, result.err_phase, on_crud_error, mut e, mut w,
@@ -706,7 +706,7 @@ fn data_grid_crud_apply_save_result(grid_id string, result DataGridCrudMutationR
 
 // Finalizes a successful save: clears dirty state, updates
 // signatures, triggers on_rows_change callback and refetch.
-fn data_grid_crud_finish_save(grid_id string, replace_ids map[string]string, row_count ?int, on_rows_change fn (rows_ []gui.GridRow, mut e Event, mut w Window), has_source bool, focus_id u32, mut e Event, mut w Window) {
+fn data_grid_crud_finish_save(grid_id string, _ map[string]string, row_count ?int, on_rows_change fn (rows_ []GridRow, mut e Event, mut w Window), has_source bool, focus_id u32, mut e Event, mut w Window) {
 	mut state := state_map[string, DataGridCrudState](mut w, ns_dg_crud, cap_moderate).get(grid_id) or {
 		DataGridCrudState{}
 	}
@@ -737,7 +737,7 @@ fn data_grid_crud_finish_save(grid_id string, replace_ids map[string]string, row
 	}
 }
 
-fn data_grid_crud_restore_on_error(grid_id string, phase string, on_crud_error fn (msg string, mut e Event, mut w Window), mut e Event, mut w Window, snapshot_rows []gui.GridRow, err_msg string) {
+fn data_grid_crud_restore_on_error(grid_id string, phase string, on_crud_error fn (msg string, mut e Event, mut w Window), mut e Event, mut w Window, snapshot_rows []GridRow, err_msg string) {
 	// Re-fetch authoritative state from view_state to avoid
 	// overwriting edits made between snapshot and error.
 	mut state := state_map[string, DataGridCrudState](mut w, ns_dg_crud, cap_moderate).get(grid_id) or {

--- a/view_data_grid_events.v
+++ b/view_data_grid_events.v
@@ -1041,7 +1041,7 @@ fn data_grid_selection_for_target_row(key_ctx DataGridKeydownContext, target_row
 	}
 }
 
-fn data_grid_range_selected_rows(rows []gui.GridRow, start int, end int, target_row_id string) map[string]bool {
+fn data_grid_range_selected_rows(rows []GridRow, start int, end int, target_row_id string) map[string]bool {
 	mut selected := map[string]bool{}
 	if start >= 0 && end >= start {
 		for row_idx in start .. end + 1 {
@@ -1103,7 +1103,7 @@ fn data_grid_next_page_index_for_key(page_index int, page_count int, e &Event) ?
 	}
 }
 
-fn data_grid_selected_rows(rows []gui.GridRow, selection GridSelection) []gui.GridRow {
+fn data_grid_selected_rows(rows []GridRow, selection GridSelection) []GridRow {
 	if selection.selected_row_ids.len == 0 {
 		return []
 	}
@@ -1133,7 +1133,7 @@ fn data_grid_page_rows(cfg DataGridCfg, row_height f32) int {
 	return if page < 1 { 1 } else { page }
 }
 
-fn data_grid_active_row_index(rows []gui.GridRow, selection GridSelection) int {
+fn data_grid_active_row_index(rows []GridRow, selection GridSelection) int {
 	res := data_grid_active_row_index_strict(rows, selection)
 	if res >= 0 {
 		return res
@@ -1146,7 +1146,7 @@ fn data_grid_active_row_index(rows []gui.GridRow, selection GridSelection) int {
 
 // Single-pass scan: checks active_row_id and falls back
 // to first selected row in one loop instead of two.
-fn data_grid_active_row_index_strict(rows []gui.GridRow, selection GridSelection) int {
+fn data_grid_active_row_index_strict(rows []GridRow, selection GridSelection) int {
 	if rows.len == 0 {
 		return -1
 	}
@@ -1320,7 +1320,7 @@ fn data_grid_anchor_row_id(cfg DataGridCfg, mut w Window, fallback string) strin
 	return data_grid_anchor_row_id_ex(cfg.selection, cfg.id, cfg.rows, mut w, fallback)
 }
 
-fn data_grid_anchor_row_id_ex(selection GridSelection, grid_id string, rows []gui.GridRow, mut w Window, fallback string) string {
+fn data_grid_anchor_row_id_ex(selection GridSelection, grid_id string, rows []GridRow, mut w Window, fallback string) string {
 	if selection.anchor_row_id.len > 0 {
 		return selection.anchor_row_id
 	}
@@ -1350,7 +1350,7 @@ fn data_grid_set_anchor(grid_id string, anchor string, mut w Window) {
 	})
 }
 
-fn data_grid_range_indices(rows []gui.GridRow, a string, b string) (int, int) {
+fn data_grid_range_indices(rows []GridRow, a string, b string) (int, int) {
 	mut a_idx := -1
 	mut b_idx := -1
 	for idx, row in rows {

--- a/view_data_grid_rows.v
+++ b/view_data_grid_rows.v
@@ -347,11 +347,11 @@ fn data_grid_cell_editor_view(cfg DataGridCfg, row_id string, row_idx int, col G
 			)
 		}
 		.date {
-			date := data_grid_parse_editor_date(value)
+			editor_date := data_grid_parse_editor_date(value)
 			editor = window.input_date(
 				id:          editor_id
 				id_focus:    editor_focus_id
-				date:        date
+				date:        editor_date
 				sizing:      fill_fill
 				padding:     padding_none
 				size_border: 0
@@ -456,7 +456,7 @@ fn make_data_grid_editor_on_keydown(grid_id string, grid_focus_id u32) fn (&Layo
 	}
 }
 
-fn data_grid_track_row_edit_click(grid_id string, edit_enabled bool, editor_focus_base u32, col_count int, columns []GridColumnCfg, row_idx int, row_id string, grid_focus_id u32, mut e Event, mut w Window) {
+fn data_grid_track_row_edit_click(grid_id string, edit_enabled bool, editor_focus_base u32, col_count int, columns []GridColumnCfg, _ int, row_id string, grid_focus_id u32, mut e Event, mut w Window) {
 	if !edit_enabled || data_grid_has_keyboard_modifiers(&e) {
 		return
 	}

--- a/view_date_picker_roller.v
+++ b/view_date_picker_roller.v
@@ -52,16 +52,16 @@ pub fn date_picker_roller(cfg DatePickerRollerCfg) View {
 
 	// Calculate total min_width if not specified
 	spacing := f32(4)
-	padding := f32(10) // padding_small
+	drum_padding := f32(10) // padding_small
 	calculated_min_width := match cfg.display_mode {
 		.day_month_year, .month_day_year {
-			day_drum_width + month_drum_width + year_drum_width + spacing * 2 + padding * 2
+			day_drum_width + month_drum_width + year_drum_width + spacing * 2 + drum_padding * 2
 		}
 		.month_year {
-			month_drum_width + year_drum_width + spacing + padding * 2
+			month_drum_width + year_drum_width + spacing + drum_padding * 2
 		}
 		.year_only {
-			year_drum_width + padding * 2
+			year_drum_width + drum_padding * 2
 		}
 	}
 

--- a/view_draw_canvas.v
+++ b/view_draw_canvas.v
@@ -25,10 +25,10 @@ pub:
 	clip            bool  = true
 	color           Color = color_transparent
 	radius          f32
-	on_draw         fn (mut gui.DrawContext)                           = unsafe { nil }
-	on_click        fn (&gui.Layout, mut gui.Event, mut gui.Window)    = unsafe { nil }
-	on_hover        fn (mut gui.Layout, mut gui.Event, mut gui.Window) = unsafe { nil }
-	on_mouse_scroll fn (&gui.Layout, mut gui.Event, mut gui.Window)    = unsafe { nil }
+	on_draw         fn (mut DrawContext)                   = unsafe { nil }
+	on_click        fn (&Layout, mut Event, mut Window)    = unsafe { nil }
+	on_hover        fn (mut Layout, mut Event, mut Window) = unsafe { nil }
+	on_mouse_scroll fn (&Layout, mut Event, mut Window)    = unsafe { nil }
 }
 
 fn (mut cv DrawCanvasView) generate_layout(mut window Window) Layout {

--- a/view_form.v
+++ b/view_form.v
@@ -311,7 +311,7 @@ fn form_resolve_validate_on(override FormValidateOn, fallback FormValidateOn) Fo
 	return override
 }
 
-fn form_merge_errors(field FormFieldRuntimeState) []gui.FormIssue {
+fn form_merge_errors(field FormFieldRuntimeState) []FormIssue {
 	mut merged := []FormIssue{cap: field.sync_errors.len + field.async_errors.len}
 	merged << field.sync_errors
 	merged << field.async_errors
@@ -434,7 +434,7 @@ pub fn (window &Window) form_field_state(form_id string, field_id string) ?FormF
 	return form_to_public_field_state(field)
 }
 
-pub fn (window &Window) form_field_errors(form_id string, field_id string) []gui.FormIssue {
+pub fn (window &Window) form_field_errors(form_id string, field_id string) []FormIssue {
 	if field := window.form_field_state(form_id, field_id) {
 		return field.errors
 	}
@@ -655,7 +655,7 @@ fn (mut w Window) form_queue_async_validation_pin_release() {
 	})
 }
 
-fn (mut w Window) form_apply_async_result(form_id string, field_id string, request_id u64, issues []gui.FormIssue) {
+fn (mut w Window) form_apply_async_result(form_id string, field_id string, request_id u64, issues []FormIssue) {
 	mut state := form_state_get(mut w, form_id)
 	mut field := state.fields[field_id] or { return }
 	if request_id != field.request_seq {

--- a/view_image.v
+++ b/view_image.v
@@ -83,7 +83,7 @@ fn (mut iv ImageView) generate_layout(mut window Window) Layout {
 		}
 	}
 
-	image := window.load_image(image_path) or {
+	loaded_image := window.load_image(image_path) or {
 		log.error('${@FILE_LINE} > ${err.msg()}')
 		mut error_text := text(
 			text:       '[missing: ${iv.src}]'
@@ -95,8 +95,8 @@ fn (mut iv ImageView) generate_layout(mut window Window) Layout {
 		return error_text.generate_layout(mut window)
 	}
 
-	width := if iv.width > 0 { iv.width } else { image.width }
-	height := if iv.height > 0 { iv.height } else { image.height }
+	width := if iv.width > 0 { iv.width } else { loaded_image.width }
+	height := if iv.height > 0 { iv.height } else { loaded_image.height }
 
 	mut events := unsafe { &EventHandlers(nil) }
 	if iv.on_click != unsafe { nil } || iv.on_hover != unsafe { nil } {

--- a/view_image_xtra.v
+++ b/view_image_xtra.v
@@ -31,9 +31,9 @@ pub fn (mut window Window) load_image_no_validate(file_name string) !&Image {
 	real_path := os.real_path(file_name)
 	mut ctx := window.context()
 	return ctx.get_cached_image_by_idx(window.view_state.image_map.get(real_path) or {
-		image := ctx.create_image(file_name)! // ctx.create_image caches images
-		window.view_state.image_map.set(real_path, image.id, mut ctx)
-		return &image
+		cached_image := ctx.create_image(file_name)! // ctx.create_image caches images
+		window.view_state.image_map.set(real_path, cached_image.id, mut ctx)
+		return &cached_image
 	})
 }
 

--- a/view_input.v
+++ b/view_input.v
@@ -554,25 +554,25 @@ fn (cfg &InputCfg) apply_text_edit(input_state InputState, text string, cursor_p
 }
 
 fn (cfg &InputCfg) commit_text(layout &Layout, reason InputCommitReason, mut w Window) {
-	mut text := cfg.text
+	mut edited_text := cfg.text
 	if cfg.post_commit_normalize != unsafe { nil } {
-		text = cfg.post_commit_normalize(cfg.text, reason)
+		edited_text = cfg.post_commit_normalize(cfg.text, reason)
 	}
 	match reason {
 		.blur {
-			cfg.form_notify(layout, text, .blur, mut w)
+			cfg.form_notify(layout, edited_text, .blur, mut w)
 		}
 		.enter {
-			cfg.form_notify(layout, text, .submit, mut w)
+			cfg.form_notify(layout, edited_text, .submit, mut w)
 			w.form_request_submit_for_layout(layout)
 		}
 	}
 
-	if cfg.on_text_changed != unsafe { nil } && text != cfg.text {
-		cfg.on_text_changed(layout, text, mut w)
+	if cfg.on_text_changed != unsafe { nil } && edited_text != cfg.text {
+		cfg.on_text_changed(layout, edited_text, mut w)
 	}
 	if cfg.on_text_commit != unsafe { nil } {
-		cfg.on_text_commit(layout, text, reason, mut w)
+		cfg.on_text_commit(layout, edited_text, reason, mut w)
 	}
 }
 
@@ -612,37 +612,37 @@ fn (cfg &InputCfg) delete(mut w Window, forward_delete bool) ?string {
 	if compiled := cfg.active_compiled_mask() {
 		return cfg.masked_delete(mut w, forward_delete, compiled)
 	}
-	mut text := cfg.text.runes()
+	mut runes := cfg.text.runes()
 	input_state := input_state_or_default(cfg.id_focus, mut w)
-	mut cursor_pos := int_min(input_state.cursor_pos, text.len)
+	mut cursor_pos := int_min(input_state.cursor_pos, runes.len)
 	if cursor_pos < 0 {
-		cursor_pos = text.len
+		cursor_pos = runes.len
 	}
 	if input_state.select_beg != input_state.select_end {
 		beg, end := u32_sort(input_state.select_beg, input_state.select_end)
-		if beg >= text.len || end > text.len {
+		if beg >= runes.len || end > runes.len {
 			log.error('beg or end out of range (delete)')
 			return none
 		}
-		text = arrays.append(text[..beg], text[end..])
-		cursor_pos = int_min(int(beg), text.len)
+		runes = arrays.append(runes[..beg], runes[end..])
+		cursor_pos = int_min(int(beg), runes.len)
 	} else {
 		if cursor_pos == 0 && !forward_delete {
-			return text.string()
+			return runes.string()
 		}
-		if cursor_pos == text.len && forward_delete {
-			return text.string()
+		if cursor_pos == runes.len && forward_delete {
+			return runes.string()
 		}
 		delete_pos := if forward_delete { cursor_pos } else { cursor_pos - 1 }
-		if delete_pos < 0 || delete_pos >= text.len {
+		if delete_pos < 0 || delete_pos >= runes.len {
 			return none
 		}
-		text = arrays.append(text[..delete_pos], text[delete_pos + 1..])
+		runes = arrays.append(runes[..delete_pos], runes[delete_pos + 1..])
 		if !forward_delete {
 			cursor_pos--
 		}
 	}
-	return cfg.apply_text_edit(input_state, text.string(), cursor_pos, mut w)
+	return cfg.apply_text_edit(input_state, runes.string(), cursor_pos, mut w)
 }
 
 // insert adds text at the cursor or replaces selection. For single-line
@@ -664,24 +664,24 @@ fn (cfg &InputCfg) insert(insert_text string, mut w Window) !string {
 	if cfg.exceeds_single_line_fixed_width(cfg.text + insert_value, mut w) {
 		return cfg.text
 	}
-	mut text := cfg.text.runes()
+	mut runes := cfg.text.runes()
 	input_state := input_state_or_default(cfg.id_focus, mut w)
-	mut cursor_pos := int_min(input_state.cursor_pos, text.len)
+	mut cursor_pos := int_min(input_state.cursor_pos, runes.len)
 	if cursor_pos < 0 {
-		text = arrays.append(cfg.text.runes(), insert_runes)
-		cursor_pos = text.len
+		runes = arrays.append(cfg.text.runes(), insert_runes)
+		cursor_pos = runes.len
 	} else if input_state.select_beg != input_state.select_end {
 		beg, end := u32_sort(input_state.select_beg, input_state.select_end)
-		if beg >= text.len || end > text.len {
+		if beg >= runes.len || end > runes.len {
 			return error('beg or end out of range (insert)')
 		}
-		text = arrays.append(arrays.append(text[..beg], insert_runes), text[end..])
-		cursor_pos = int_min(int(beg) + insert_runes.len, text.len)
+		runes = arrays.append(arrays.append(runes[..beg], insert_runes), runes[end..])
+		cursor_pos = int_min(int(beg) + insert_runes.len, runes.len)
 	} else {
-		text = arrays.append(arrays.append(text[..cursor_pos], insert_runes), text[cursor_pos..])
-		cursor_pos = int_min(cursor_pos + insert_runes.len, text.len)
+		runes = arrays.append(arrays.append(runes[..cursor_pos], insert_runes), runes[cursor_pos..])
+		cursor_pos = int_min(cursor_pos + insert_runes.len, runes.len)
 	}
-	return cfg.apply_text_edit(input_state, text.string(), cursor_pos, mut w)
+	return cfg.apply_text_edit(input_state, runes.string(), cursor_pos, mut w)
 }
 
 // cut copies selected text to clipboard then deletes it. Returns modified
@@ -771,41 +771,41 @@ fn make_input_on_char(cfg InputRuntimeCfg) fn (&Layout, mut Event, mut Window) {
 		if cfg.on_text_changed == unsafe { nil } {
 			return
 		}
-		mut text := cfg.text
+		mut edited_text := cfg.text
 		if event.modifiers == .ctrl_shift {
 			match c {
-				ctrl_z { text = cfg.redo(mut w) }
+				ctrl_z { edited_text = cfg.redo(mut w) }
 				else {}
 			}
 		} else if event.modifiers == .super_shift {
 			match c {
-				cmd_z { text = cfg.redo(mut w) }
+				cmd_z { edited_text = cfg.redo(mut w) }
 				else {}
 			}
 		} else if event.modifiers == .ctrl {
 			match c {
-				ctrl_v { text = cfg.paste(from_clipboard(), mut w) or { return } }
-				ctrl_x { text = cfg.cut(mut w) or { return } }
-				ctrl_z { text = cfg.undo(mut w) }
+				ctrl_v { edited_text = cfg.paste(from_clipboard(), mut w) or { return } }
+				ctrl_x { edited_text = cfg.cut(mut w) or { return } }
+				ctrl_z { edited_text = cfg.undo(mut w) }
 				else {}
 			}
 		} else if event.modifiers == .super {
 			match c {
-				cmd_v { text = cfg.paste(from_clipboard(), mut w) or { return } }
-				cmd_x { text = cfg.cut(mut w) or { return } }
-				cmd_z { text = cfg.undo(mut w) }
+				cmd_v { edited_text = cfg.paste(from_clipboard(), mut w) or { return } }
+				cmd_x { edited_text = cfg.cut(mut w) or { return } }
+				cmd_z { edited_text = cfg.undo(mut w) }
 				else {}
 			}
 		} else {
 			match c {
 				bsp_char {
-					text = cfg.delete(mut w, false) or { return }
+					edited_text = cfg.delete(mut w, false) or { return }
 				}
 				del_char {
 					$if macos {
-						text = cfg.delete(mut w, false) or { return }
+						edited_text = cfg.delete(mut w, false) or { return }
 					} $else {
-						text = cfg.delete(mut w, true) or { return }
+						edited_text = cfg.delete(mut w, true) or { return }
 					}
 				}
 				cr_char, lf_char {
@@ -821,7 +821,7 @@ fn make_input_on_char(cfg InputRuntimeCfg) fn (&Layout, mut Event, mut Window) {
 						event.is_handled = true
 						return
 					}
-					text = cfg.insert('\n', mut w) or {
+					edited_text = cfg.insert('\n', mut w) or {
 						log.error(err.msg())
 						return
 					}
@@ -830,7 +830,7 @@ fn make_input_on_char(cfg InputRuntimeCfg) fn (&Layout, mut Event, mut Window) {
 					return
 				}
 				else {
-					text = cfg.insert(rune(c).str(), mut w) or {
+					edited_text = cfg.insert(rune(c).str(), mut w) or {
 						log.error(err.msg())
 						return
 					}
@@ -838,9 +838,9 @@ fn make_input_on_char(cfg InputRuntimeCfg) fn (&Layout, mut Event, mut Window) {
 			}
 		}
 		event.is_handled = true
-		if text != cfg.text {
-			cfg.form_notify(layout, text, .change, mut w)
-			cfg.on_text_changed(layout, text, mut w)
+		if edited_text != cfg.text {
+			cfg.form_notify(layout, edited_text, .change, mut w)
+			cfg.on_text_changed(layout, edited_text, mut w)
 		}
 	}
 }

--- a/view_markdown.v
+++ b/view_markdown.v
@@ -108,7 +108,7 @@ fn markdown_warn_external_api_once(mut w Window) {
 }
 
 // build_markdown_table_data converts parsed table to TableRowCfg array.
-fn build_markdown_table_data(parsed ParsedTable, style MarkdownStyle) []TableRowCfg {
+fn build_markdown_table_data(parsed ParsedTable, _ MarkdownStyle) []TableRowCfg {
 	mut rows := []TableRowCfg{cap: parsed.rows.len + 1}
 	// Header row
 	mut header_cells := []TableCellCfg{cap: parsed.headers.len}

--- a/view_menu.v
+++ b/view_menu.v
@@ -61,7 +61,7 @@ fn menu_build(cfg MenubarCfg, level int, items []MenuItemCfg, window &Window) []
 
 		// Choose padding depending on whether item has a custom view,
 		// is a subtitle, or is a normal item.
-		padding := match item.custom_view != none {
+		item_padding := match item.custom_view != none {
 			true {
 				item.padding
 			}
@@ -82,7 +82,7 @@ fn menu_build(cfg MenubarCfg, level int, items []MenuItemCfg, window &Window) []
 		item_cfg := MenuItemCfg{
 			...item
 			color_select: cfg.color_select
-			padding:      padding
+			padding:      item_padding
 			selected:     item.id == id_selected || selected_in_tree
 			sizing:       sizing
 			radius:       cfg.radius_menu_item

--- a/view_menubar.v
+++ b/view_menubar.v
@@ -245,7 +245,7 @@ fn menu_mapper(menu []MenuItemCfg) MenuIdMap {
 // right enters submenu if present, otherwise uses the root-level right
 // up/down move vertically within the submenu, with wraparound to last/first selectable items
 // Recursively processes nested submenu levels to complete the graph.
-fn submenu_mapper(menu []MenuItemCfg, left_id string, node MenuIdNode, root_node MenuIdNode, mut menu_map MenuIdMap) {
+fn submenu_mapper(menu []MenuItemCfg, left_id string, _ MenuIdNode, root_node MenuIdNode, mut menu_map MenuIdMap) {
 	for idx, item in menu {
 		if !is_selectable_menu_id(item.id) {
 			continue

--- a/view_numeric_input.v
+++ b/view_numeric_input.v
@@ -163,7 +163,7 @@ pub fn numeric_input(cfg NumericInputCfg) View {
 fn numeric_input_field(cfg NumericInputCfg, locale NumericLocaleCfg, step_cfg NumericStepCfg, fill_parent bool) View {
 	sizing := if fill_parent { fill_fill } else { cfg.sizing }
 	input_id := if fill_parent && cfg.id.len > 0 { '${cfg.id}_field' } else { cfg.id }
-	tooltip := if fill_parent { unsafe { nil } } else { cfg.tooltip }
+	field_tooltip := if fill_parent { unsafe { nil } } else { cfg.tooltip }
 	color := if fill_parent { color_transparent } else { cfg.color }
 	color_hover := if fill_parent { color_transparent } else { cfg.color_hover }
 	color_border := if fill_parent { color_transparent } else { cfg.color_border }
@@ -176,7 +176,7 @@ fn numeric_input_field(cfg NumericInputCfg, locale NumericLocaleCfg, step_cfg Nu
 		id_focus:              cfg.id_focus
 		text:                  cfg.text
 		placeholder:           cfg.placeholder
-		tooltip:               tooltip
+		tooltip:               field_tooltip
 		sizing:                sizing
 		width:                 if fill_parent { 0 } else { cfg.width }
 		height:                if fill_parent { 0 } else { cfg.height }
@@ -485,48 +485,48 @@ fn numeric_mode_parse_value(raw string, decimals int, locale NumericLocaleCfg, m
 
 fn numeric_mode_is_transient_input(raw string, locale NumericLocaleCfg, mode_cfg NumericModeCfg) bool {
 	loc := numeric_locale_normalize(locale)
-	mut text := raw.trim_space()
-	if text.len == 0 {
+	mut normalized_text := raw.trim_space()
+	if normalized_text.len == 0 {
 		return true
 	}
 	minus := loc.minus_sign.str()
 	plus := loc.plus_sign.str()
-	if minus.len > 0 && text == minus {
+	if minus.len > 0 && normalized_text == minus {
 		return true
 	}
-	if plus.len > 0 && text == plus {
+	if plus.len > 0 && normalized_text == plus {
 		return true
 	}
-	if minus.len > 0 && text.starts_with(minus) {
-		text = text[minus.len..].trim_left(' \t')
-	} else if plus.len > 0 && text.starts_with(plus) {
-		text = text[plus.len..].trim_left(' \t')
+	if minus.len > 0 && normalized_text.starts_with(minus) {
+		normalized_text = normalized_text[minus.len..].trim_left(' \t')
+	} else if plus.len > 0 && normalized_text.starts_with(plus) {
+		normalized_text = normalized_text[plus.len..].trim_left(' \t')
 	}
-	if text.len == 0 {
+	if normalized_text.len == 0 {
 		return true
 	}
 	if mode_cfg.affix.len > 0 {
 		match mode_cfg.affix_position {
 			.prefix {
-				if text == mode_cfg.affix {
+				if normalized_text == mode_cfg.affix {
 					return true
 				}
-				if text.starts_with(mode_cfg.affix) {
-					text = text[mode_cfg.affix.len..].trim_left(' \t')
-					if text.len == 0 {
+				if normalized_text.starts_with(mode_cfg.affix) {
+					normalized_text = normalized_text[mode_cfg.affix.len..].trim_left(' \t')
+					if normalized_text.len == 0 {
 						return true
 					}
 				}
 			}
 			.suffix {
-				if text == mode_cfg.affix {
+				if normalized_text == mode_cfg.affix {
 					return true
 				}
-				mut right := text.trim_right(' \t')
+				mut right := normalized_text.trim_right(' \t')
 				if right.ends_with(mode_cfg.affix) {
 					right = right[..right.len - mode_cfg.affix.len].trim_right(' \t')
-					text = right
-					if text.len == 0 {
+					normalized_text = right
+					if normalized_text.len == 0 {
 						return true
 					}
 				}
@@ -537,13 +537,13 @@ fn numeric_mode_is_transient_input(raw string, locale NumericLocaleCfg, mode_cfg
 	if decimal_sep.len == 0 {
 		return false
 	}
-	if text == decimal_sep {
+	if normalized_text == decimal_sep {
 		return true
 	}
-	if !text.ends_with(decimal_sep) {
+	if !normalized_text.ends_with(decimal_sep) {
 		return false
 	}
-	prefix := text[..text.len - decimal_sep.len]
+	prefix := normalized_text[..normalized_text.len - decimal_sep.len]
 	if prefix.len == 0 {
 		return true
 	}
@@ -561,41 +561,41 @@ fn numeric_mode_format_value(value f64, decimals int, locale NumericLocaleCfg, m
 }
 
 fn numeric_strip_affix(raw string, locale NumericLocaleCfg, mode_cfg NumericModeCfg) ?string {
-	mut text := raw.trim_space()
-	if text.len == 0 {
+	mut stripped_text := raw.trim_space()
+	if stripped_text.len == 0 {
 		return none
 	}
 	mut sign := ''
 	minus := locale.minus_sign.str()
 	plus := locale.plus_sign.str()
-	if minus.len > 0 && text.starts_with(minus) {
+	if minus.len > 0 && stripped_text.starts_with(minus) {
 		sign = minus
-		text = text[minus.len..].trim_left(' \t')
-	} else if plus.len > 0 && text.starts_with(plus) {
+		stripped_text = stripped_text[minus.len..].trim_left(' \t')
+	} else if plus.len > 0 && stripped_text.starts_with(plus) {
 		sign = plus
-		text = text[plus.len..].trim_left(' \t')
+		stripped_text = stripped_text[plus.len..].trim_left(' \t')
 	}
 	if mode_cfg.affix.len > 0 {
 		match mode_cfg.affix_position {
 			.prefix {
-				if text.starts_with(mode_cfg.affix) {
-					text = text[mode_cfg.affix.len..].trim_left(' \t')
+				if stripped_text.starts_with(mode_cfg.affix) {
+					stripped_text = stripped_text[mode_cfg.affix.len..].trim_left(' \t')
 				}
 			}
 			.suffix {
-				mut right := text.trim_right(' \t')
+				mut right := stripped_text.trim_right(' \t')
 				if right.ends_with(mode_cfg.affix) {
 					right = right[..right.len - mode_cfg.affix.len].trim_right(' \t')
 				}
-				text = right
+				stripped_text = right
 			}
 		}
 	}
-	text = text.trim_space()
-	if text.len == 0 {
+	stripped_text = stripped_text.trim_space()
+	if stripped_text.len == 0 {
 		return none
 	}
-	return sign + text
+	return sign + stripped_text
 }
 
 fn numeric_apply_affix(formatted string, locale NumericLocaleCfg, mode_cfg NumericModeCfg) string {

--- a/view_range_slider.v
+++ b/view_range_slider.v
@@ -221,7 +221,7 @@ fn range_slider_amend_layout_slide(mut layout Layout, mut w Window, on_change fn
 		return
 	}
 	mut left_bar := unsafe { &track.children[0] }
-	mut thumb := unsafe { &track.children[1] }
+	mut thumb_layout := unsafe { &track.children[1] }
 
 	clamped := f32_clamp(value, min, max)
 	percent := math.abs(clamped / (max - min))
@@ -243,8 +243,8 @@ fn range_slider_amend_layout_slide(mut layout Layout, mut w Window, on_change fn
 	}
 
 	if w.is_focus(id_focus) {
-		thumb.shape.color = color_focus
-		thumb.shape.color_border = color_focus
+		thumb_layout.shape.color = color_focus
+		thumb_layout.shape.color_border = color_focus
 	}
 }
 
@@ -270,12 +270,12 @@ fn range_slider_amend_layout_thumb(mut layout Layout, mut _ Window, value f32, m
 // range_slider_mouse_move handles mouse move during drag.
 fn range_slider_mouse_move(layout &Layout, mut e Event, mut w Window, slider_id string, on_change fn (f32, mut Event, mut Window), cur_value f32, min f32, max f32, vertical bool, round_value bool) {
 	if on_change != unsafe { nil } {
-		range_slider := layout.find_layout(fn [slider_id] (n Layout) bool {
+		slider_layout := layout.find_layout(fn [slider_id] (n Layout) bool {
 			return n.shape.id == slider_id
 		})
-		if range_slider != none {
+		if slider_layout != none {
 			w.set_mouse_cursor_pointing_hand()
-			shape := range_slider.shape
+			shape := slider_layout.shape
 			if vertical {
 				height := shape.height
 				percent := f32_clamp((e.mouse_y - shape.y) / height, 0, 1)

--- a/view_select.v
+++ b/view_select.v
@@ -281,7 +281,7 @@ fn (cfg &SelectCfg) select_on_keydown(mut e Event, mut w Window) {
 	}
 }
 
-fn option_view(cfg &SelectCfg, option string, index int, highlighted bool, id_scroll u32) View {
+fn option_view(cfg &SelectCfg, option string, index int, highlighted bool, _ u32) View {
 	select_multiple := cfg.select_multiple
 	on_select := cfg.on_select
 	select_array := cfg.select

--- a/view_table.v
+++ b/view_table.v
@@ -340,8 +340,10 @@ pub fn table_cfg_from_csv_string(data string) !TableCfg {
 	// Parse rows with error context
 	mut rows := [][]string{cap: int(row_count)}
 	for y in 0 .. int(row_count) {
-		row := parser.get_row(y) or { return error('failed to parse CSV row ${y}: ${err.msg()}') }
-		rows << row
+		csv_row := parser.get_row(y) or {
+			return error('failed to parse CSV row ${y}: ${err.msg()}')
+		}
+		rows << csv_row
 	}
 	return table_cfg_from_data(rows)
 }
@@ -436,8 +438,8 @@ fn table_data_hash(cfg &TableCfg) u64 {
 	sample_indices := [0, cfg.data.len / 2, cfg.data.len - 1]
 	for idx in sample_indices {
 		if idx >= 0 && idx < cfg.data.len {
-			row := cfg.data[idx]
-			for cell in row.cells {
+			sample_row := cfg.data[idx]
+			for cell in sample_row.cells {
 				for c in cell.value {
 					h = h * 31 + u64(c)
 				}

--- a/view_text_cursor.v
+++ b/view_text_cursor.v
@@ -31,7 +31,7 @@ fn cursor_right(shape Shape, pos int) int {
 }
 
 // cursor_up moves the cursor position up one line using vglyph geometry.
-fn cursor_up(shape Shape, cursor_pos int, cursor_offset f32, lines_up int, mut window Window) int {
+fn cursor_up(shape Shape, cursor_pos int, cursor_offset f32, lines_up int, mut _ Window) int {
 	if lines_up <= 0 {
 		return cursor_pos
 	}
@@ -63,7 +63,7 @@ fn cursor_up(shape Shape, cursor_pos int, cursor_offset f32, lines_up int, mut w
 }
 
 // cursor_down moves the cursor position down one line using vglyph geometry.
-fn cursor_down(shape Shape, cursor_pos int, cursor_offset f32, lines_down int, mut window Window) int {
+fn cursor_down(shape Shape, cursor_pos int, cursor_offset f32, lines_down int, mut _ Window) int {
 	if lines_down <= 0 {
 		return cursor_pos
 	}
@@ -270,7 +270,7 @@ fn cursor_position_from_offset(str string, offset f32, style TextStyle, mut wind
 
 // offset_from_cursor_position returns the horizontal pixel offset of the cursor
 // position using vglyph geometry.
-fn offset_from_cursor_position(shape Shape, cursor_position int, mut window Window) f32 {
+fn offset_from_cursor_position(shape Shape, cursor_position int, mut _ Window) f32 {
 	byte_idx := rune_to_byte_index(shape.tc.text, cursor_position)
 	if !shape.has_text_layout() {
 		return 0
@@ -334,7 +334,7 @@ fn cursor_pos_to_scroll_y(cursor_pos int, shape &Shape, mut w Window) f32 {
 	return target_scroll
 }
 
-fn cursor_pos_to_scroll_x(cursor_pos int, shape &Shape, mut w Window) f32 {
+fn cursor_pos_to_scroll_x(_cursor_pos int, _shape &Shape, mut _w Window) f32 {
 	return 0
 }
 
@@ -364,7 +364,7 @@ fn cursor_pos_to_scroll_x(cursor_pos int, shape &Shape, mut w Window) f32 {
 
 // mouse_cursor_pos determines the character index (cursor position) within
 // the entire text based on the mouse coordinates using vglyph geometry.
-fn (tv &TextView) mouse_cursor_pos(shape &Shape, e &Event, mut w Window) int {
+fn (tv &TextView) mouse_cursor_pos(shape &Shape, e &Event, mut _ Window) int {
 	if tv.placeholder_active {
 		return 0
 	}
@@ -391,7 +391,7 @@ fn scroll_cursor_into_view(cursor_pos int, layout &Layout, mut w Window) {
 
 // text_mouse_cursor_pos is a standalone version of mouse_cursor_pos that
 // takes placeholder_active as a parameter instead of capturing tv.
-fn text_mouse_cursor_pos(shape &Shape, e &Event, mut w Window, placeholder_active bool) int {
+fn text_mouse_cursor_pos(shape &Shape, e &Event, mut _ Window, placeholder_active bool) int {
 	if placeholder_active {
 		return 0
 	}

--- a/view_tree.v
+++ b/view_tree.v
@@ -345,7 +345,7 @@ fn tree_visible_range(tree_height f32, row_height f32, total_rows int, id_scroll
 }
 
 // tree_flat_row_content builds the inner content view for ghost.
-fn tree_flat_row_content(flat_row TreeFlatRow, indent f32, min_width_icon f32) View {
+fn tree_flat_row_content(flat_row TreeFlatRow, _indent f32, min_width_icon f32) View {
 	arrow := tree_arrow_icon(flat_row)
 	return row(
 		name:    'tree node content'

--- a/window.v
+++ b/window.v
@@ -119,7 +119,7 @@ pub fn window(cfg &WindowCfg) &Window {
 	log.set_level(cfg.log_level)
 	log.set_always_flush(true)
 
-	mut window := &Window{
+	mut app_window := &Window{
 		state:                    cfg.state
 		on_event:                 cfg.on_event
 		debug_layout:             cfg.debug_layout
@@ -130,7 +130,7 @@ pub fn window(cfg &WindowCfg) &Window {
 	}
 	on_init := cfg.on_init
 	cursor_blink := cfg.cursor_blink
-	window.ui = gg.new_context(
+	app_window.ui = gg.new_context(
 		bg_color:                     cfg.bg_color.to_gx_color()
 		width:                        cfg.width
 		height:                       cfg.height
@@ -143,7 +143,7 @@ pub fn window(cfg &WindowCfg) &Window {
 		frame_fn:                     frame_fn
 		cleanup_fn:                   window_cleanup
 		ui_mode:                      true // only draw on events
-		user_data:                    window
+		user_data:                    app_window
 		init_fn:                      fn [on_init, cursor_blink] (mut w Window) {
 			w.update_window_size()
 
@@ -175,10 +175,10 @@ pub fn window(cfg &WindowCfg) &Window {
 	)
 
 	$if !prod {
-		at_exit(fn [window] () {
-			println(window.stats())
+		at_exit(fn [app_window] () {
+			println(app_window.stats())
 		}) or {}
 	}
 
-	return window
+	return app_window
 }


### PR DESCRIPTION
## Summary

Small hygiene pass for v-gui.

It cleans up V notices reported by CI without changing runtime behavior, and makes the existing CI `Run tests` steps easier to read on Linux, macOS, and Windows.

## Changes

- Acknowledge unused parameters in v-gui code while preserving existing function signatures.
- Keep `dock_layout_tree` immutable/copy-on-write behavior while removing immutable-root notices.
- Add focused regression coverage for dock layout tree operations.
- Make CI `Run tests` steps print the tracked test file count and `[i/N]` test file list before running the existing `v test gui/`.

## Tests

```sh
git diff --check
v fmt -verify -inprocess .
VJOBS=1 v -no-parallel test .